### PR TITLE
feat: 在linux上集成slepc

### DIFF
--- a/3rd/slepc/linux/include/slepc.h
+++ b/3rd/slepc/linux/include/slepc.h
@@ -1,0 +1,20 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   Include all top-level SLEPc functionality
+*/
+
+#pragma once
+
+#include <slepcsvd.h>
+#include <slepcpep.h>
+#include <slepcnep.h>
+#include <slepcmfn.h>
+#include <slepclme.h>

--- a/3rd/slepc/linux/include/slepc/finclude/slepc.h
+++ b/3rd/slepc/linux/include/slepc/finclude/slepc.h
@@ -1,0 +1,23 @@
+!
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  SLEPc - Scalable Library for Eigenvalue Problem Computations
+!  Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+!
+!  This file is part of SLEPc.
+!  SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!
+!  Single Fortran include file for all of SLEPc
+!
+#include "slepc/finclude/slepcsys.h"
+#include "slepc/finclude/slepcbv.h"
+#include "slepc/finclude/slepcfn.h"
+#include "slepc/finclude/slepcds.h"
+#include "slepc/finclude/slepcrg.h"
+#include "slepc/finclude/slepcst.h"
+#include "slepc/finclude/slepceps.h"
+#include "slepc/finclude/slepcsvd.h"
+#include "slepc/finclude/slepcpep.h"
+#include "slepc/finclude/slepcnep.h"
+#include "slepc/finclude/slepcmfn.h"
+#include "slepc/finclude/slepclme.h"

--- a/3rd/slepc/linux/include/slepc/finclude/slepcbv.h
+++ b/3rd/slepc/linux/include/slepc/finclude/slepcbv.h
@@ -1,0 +1,32 @@
+!
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  SLEPc - Scalable Library for Eigenvalue Problem Computations
+!  Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+!
+!  This file is part of SLEPc.
+!  SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!
+!  Include file for Fortran use of the BV object in SLEPc
+!
+#if !defined(SLEPCBVDEF_H)
+#define SLEPCBVDEF_H
+
+#include "petsc/finclude/petscmat.h"
+
+#define BV type(tBV)
+
+#define BVType             character*(80)
+#define BVOrthogType       PetscEnum
+#define BVOrthogRefineType PetscEnum
+#define BVOrthogBlockType  PetscEnum
+#define BVMatMultType      PetscEnum
+#define BVSVDMethod        PetscEnum
+
+#define BVMAT        'mat'
+#define BVSVEC       'svec'
+#define BVVECS       'vecs'
+#define BVCONTIGUOUS 'contiguous'
+#define BVTENSOR     'tensor'
+
+#endif

--- a/3rd/slepc/linux/include/slepc/finclude/slepcds.h
+++ b/3rd/slepc/linux/include/slepc/finclude/slepcds.h
@@ -1,0 +1,38 @@
+!
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  SLEPc - Scalable Library for Eigenvalue Problem Computations
+!  Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+!
+!  This file is part of SLEPc.
+!  SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!
+!  Include file for Fortran use of the DS object in SLEPc
+!
+#if !defined(SLEPCDSDEF_H)
+#define SLEPCDSDEF_H
+
+#include "petsc/finclude/petscmat.h"
+#include "slepc/finclude/slepcfn.h"
+#include "slepc/finclude/slepcrg.h"
+
+#define DS type(tDS)
+
+#define DSType         character*(80)
+#define DSStateType    PetscEnum
+#define DSMatType      PetscEnum
+#define DSParallelType PetscEnum
+
+#define DSHEP       'hep'
+#define DSNHEP      'nhep'
+#define DSGHEP      'ghep'
+#define DSGHIEP     'ghiep'
+#define DSGNHEP     'gnhep'
+#define DSNHEPTS    'nhepts'
+#define DSSVD       'svd'
+#define DSHSVD      'hsvd'
+#define DSGSVD      'gsvd'
+#define DSPEP       'pep'
+#define DSNEP       'nep'
+
+#endif

--- a/3rd/slepc/linux/include/slepc/finclude/slepceps.h
+++ b/3rd/slepc/linux/include/slepc/finclude/slepceps.h
@@ -1,0 +1,64 @@
+!
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  SLEPc - Scalable Library for Eigenvalue Problem Computations
+!  Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+!
+!  This file is part of SLEPc.
+!  SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!
+!  Include file for Fortran use of the EPS object in SLEPc
+!
+#if !defined(SLEPCEPSDEF_H)
+#define SLEPCEPSDEF_H
+
+#include "slepc/finclude/slepcsys.h"
+#include "slepc/finclude/slepcst.h"
+#include "slepc/finclude/slepcbv.h"
+#include "slepc/finclude/slepcds.h"
+#include "slepc/finclude/slepcrg.h"
+#include "slepc/finclude/slepclme.h"
+#include "petsc/finclude/petscsnes.h"
+
+#define EPS type(tEPS)
+
+#define EPSType                character*(80)
+#define EPSConvergedReason     PetscEnum
+#define EPSErrorType           PetscEnum
+#define EPSProblemType         PetscEnum
+#define EPSWhich               PetscEnum
+#define EPSExtraction          PetscEnum
+#define EPSBalance             PetscEnum
+#define EPSConv                PetscEnum
+#define EPSStop                PetscEnum
+#define EPSPowerShiftType      PetscEnum
+#define EPSKrylovSchurBSEType  PetscEnum
+#define EPSLanczosReorthogType PetscEnum
+#define EPSPRIMMEMethod        PetscEnum
+#define EPSCISSQuadRule        PetscEnum
+#define EPSCISSExtraction      PetscEnum
+#define EPSEVSLDOSMethod       PetscEnum
+#define EPSEVSLDamping         PetscEnum
+
+#define EPSPOWER       'power'
+#define EPSSUBSPACE    'subspace'
+#define EPSARNOLDI     'arnoldi'
+#define EPSLANCZOS     'lanczos'
+#define EPSKRYLOVSCHUR 'krylovschur'
+#define EPSGD          'gd'
+#define EPSJD          'jd'
+#define EPSRQCG        'rqcg'
+#define EPSLOBPCG      'lobpcg'
+#define EPSCISS        'ciss'
+#define EPSLYAPII      'lyapii'
+#define EPSLAPACK      'lapack'
+#define EPSARPACK      'arpack'
+#define EPSTRLAN       'trlan'
+#define EPSBLOPEX      'blopex'
+#define EPSPRIMME      'primme'
+#define EPSFEAST       'feast'
+#define EPSSCALAPACK   'scalapack'
+#define EPSELEMENTAL   'elemental'
+#define EPSEVSL        'evsl'
+
+#endif

--- a/3rd/slepc/linux/include/slepc/finclude/slepcfn.h
+++ b/3rd/slepc/linux/include/slepc/finclude/slepcfn.h
@@ -1,0 +1,31 @@
+!
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  SLEPc - Scalable Library for Eigenvalue Problem Computations
+!  Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+!
+!  This file is part of SLEPc.
+!  SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!
+!  Include file for Fortran use of the FN object in SLEPc
+!
+#if !defined(SLEPCFNDEF_H)
+#define SLEPCFNDEF_H
+
+#include "petsc/finclude/petscmat.h"
+
+#define FN type(tFN)
+
+#define FNType         character*(80)
+#define FNCombineType  PetscEnum
+#define FNParallelType PetscEnum
+
+#define FNCOMBINE  'combine'
+#define FNRATIONAL 'rational'
+#define FNEXP      'exp'
+#define FNLOG      'log'
+#define FNPHI      'phi'
+#define FNSQRT     'sqrt'
+#define FNINVSQRT  'invsqrt'
+
+#endif

--- a/3rd/slepc/linux/include/slepc/finclude/slepclme.h
+++ b/3rd/slepc/linux/include/slepc/finclude/slepclme.h
@@ -1,0 +1,26 @@
+!
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  SLEPc - Scalable Library for Eigenvalue Problem Computations
+!  Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+!
+!  This file is part of SLEPc.
+!  SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!
+!  Include file for Fortran use of the LME object in SLEPc
+!
+#if !defined(SLEPCLMEDEF_H)
+#define SLEPCLMEDEF_H
+
+#include "petsc/finclude/petscmat.h"
+#include "slepc/finclude/slepcbv.h"
+
+#define LME type(tLME)
+
+#define LMEType            character*(80)
+#define LMEConvergedReason PetscEnum
+#define LMEProblemType     PetscEnum
+
+#define LMEKRYLOV      'krylov'
+
+#endif

--- a/3rd/slepc/linux/include/slepc/finclude/slepcmfn.h
+++ b/3rd/slepc/linux/include/slepc/finclude/slepcmfn.h
@@ -1,0 +1,27 @@
+!
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  SLEPc - Scalable Library for Eigenvalue Problem Computations
+!  Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+!
+!  This file is part of SLEPc.
+!  SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!
+!  Include file for Fortran use of the MFN object in SLEPc
+!
+#if !defined(SLEPCMFNDEF_H)
+#define SLEPCMFNDEF_H
+
+#include "petsc/finclude/petscmat.h"
+#include "slepc/finclude/slepcfn.h"
+#include "slepc/finclude/slepcbv.h"
+
+#define MFN type(tMFN)
+
+#define MFNType            character*(80)
+#define MFNConvergedReason PetscEnum
+
+#define MFNKRYLOV      'krylov'
+#define MFNEXPOKIT     'expokit'
+
+#endif

--- a/3rd/slepc/linux/include/slepc/finclude/slepcnep.h
+++ b/3rd/slepc/linux/include/slepc/finclude/slepcnep.h
@@ -1,0 +1,42 @@
+!
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  SLEPc - Scalable Library for Eigenvalue Problem Computations
+!  Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+!
+!  This file is part of SLEPc.
+!  SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!
+!  Include file for Fortran use of the NEP object in SLEPc
+!
+#if !defined(SLEPCNEPDEF_H)
+#define SLEPCNEPDEF_H
+
+#include "slepc/finclude/slepcbv.h"
+#include "slepc/finclude/slepcds.h"
+#include "slepc/finclude/slepcrg.h"
+#include "slepc/finclude/slepcfn.h"
+#include "slepc/finclude/slepceps.h"
+#include "slepc/finclude/slepcpep.h"
+
+#define NEP type(tNEP)
+
+#define NEPType            character*(80)
+#define NEPProblemType     PetscEnum
+#define NEPConvergedReason PetscEnum
+#define NEPErrorType       PetscEnum
+#define NEPWhich           PetscEnum
+#define NEPConv            PetscEnum
+#define NEPStop            PetscEnum
+#define NEPRefine          PetscEnum
+#define NEPRefineScheme    PetscEnum
+#define NEPCISSExtraction  PetscEnum
+
+#define NEPRII       'rii'
+#define NEPSLP       'slp'
+#define NEPNARNOLDI  'narnoldi'
+#define NEPCISS      'ciss'
+#define NEPINTERPOL  'interpol'
+#define NEPNLEIGS    'nleigs'
+
+#endif

--- a/3rd/slepc/linux/include/slepc/finclude/slepcpep.h
+++ b/3rd/slepc/linux/include/slepc/finclude/slepcpep.h
@@ -1,0 +1,45 @@
+!
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  SLEPc - Scalable Library for Eigenvalue Problem Computations
+!  Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+!
+!  This file is part of SLEPc.
+!  SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!
+!  Include file for Fortran use of the PEP object in SLEPc
+!
+#if !defined(SLEPCPEPDEF_H)
+#define SLEPCPEPDEF_H
+
+#include "slepc/finclude/slepcbv.h"
+#include "slepc/finclude/slepcst.h"
+#include "slepc/finclude/slepcds.h"
+#include "slepc/finclude/slepcrg.h"
+#include "slepc/finclude/slepceps.h"
+
+#define PEP type(tPEP)
+
+#define PEPType            character*(80)
+#define PEPProblemType     PetscEnum
+#define PEPWhich           PetscEnum
+#define PEPBasis           PetscEnum
+#define PEPScale           PetscEnum
+#define PEPRefine          PetscEnum
+#define PEPRefineScheme    PetscEnum
+#define PEPExtract         PetscEnum
+#define PEPConv            PetscEnum
+#define PEPStop            PetscEnum
+#define PEPErrorType       PetscEnum
+#define PEPConvergedReason PetscEnum
+#define PEPJDProjection    PetscEnum
+#define PEPCISSExtraction  PetscEnum
+
+#define PEPLINEAR    'linear'
+#define PEPQARNOLDI  'qarnoldi'
+#define PEPTOAR      'toar'
+#define PEPSTOAR     'stoar'
+#define PEPJD        'jd'
+#define PEPCISS      'ciss'
+
+#endif

--- a/3rd/slepc/linux/include/slepc/finclude/slepcrg.h
+++ b/3rd/slepc/linux/include/slepc/finclude/slepcrg.h
@@ -1,0 +1,27 @@
+!
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  SLEPc - Scalable Library for Eigenvalue Problem Computations
+!  Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+!
+!  This file is part of SLEPc.
+!  SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!
+!  Include file for Fortran use of the RG object in SLEPc
+!
+#if !defined(SLEPCRGDEF_H)
+#define SLEPCRGDEF_H
+
+#include "petsc/finclude/petscsys.h"
+
+#define RG type(tRG)
+
+#define RGType      character*(80)
+#define RGQuadRule  PetscEnum
+
+#define RGINTERVAL  'interval'
+#define RGPOLYGON   'polygon'
+#define RGELLIPSE   'ellipse'
+#define RGRING      'ring'
+
+#endif

--- a/3rd/slepc/linux/include/slepc/finclude/slepcst.h
+++ b/3rd/slepc/linux/include/slepc/finclude/slepcst.h
@@ -1,0 +1,30 @@
+!
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  SLEPc - Scalable Library for Eigenvalue Problem Computations
+!  Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+!
+!  This file is part of SLEPc.
+!  SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!
+!  Include file for Fortran use of the ST object in SLEPc
+!
+#if !defined(SLEPCSTDEF_H)
+#define SLEPCSTDEF_H
+
+#include "petsc/finclude/petscksp.h"
+#include "slepc/finclude/slepcbv.h"
+
+#define ST type(tST)
+
+#define STType     character*(80)
+#define STMatMode  PetscEnum
+
+#define STSHELL    'shell'
+#define STSHIFT    'shift'
+#define STSINVERT  'sinvert'
+#define STCAYLEY   'cayley'
+#define STPRECOND  'precond'
+#define STFILTER   'filter'
+
+#endif

--- a/3rd/slepc/linux/include/slepc/finclude/slepcsvd.h
+++ b/3rd/slepc/linux/include/slepc/finclude/slepcsvd.h
@@ -1,0 +1,44 @@
+!
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  SLEPc - Scalable Library for Eigenvalue Problem Computations
+!  Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+!
+!  This file is part of SLEPc.
+!  SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!
+!  Include file for Fortran use of the SVD object in SLEPc
+!
+#if !defined(SLEPCSVDDEF_H)
+#define SLEPCSVDDEF_H
+
+#include "slepc/finclude/slepcbv.h"
+#include "slepc/finclude/slepcds.h"
+#include "slepc/finclude/slepceps.h"
+
+#define SVD type(tSVD)
+
+#define SVDType             character*(80)
+#define SVDProblemType      PetscEnum
+#define SVDConvergedReason  PetscEnum
+#define SVDErrorType        PetscEnum
+#define SVDWhich            PetscEnum
+#define SVDConv             PetscEnum
+#define SVDStop             PetscEnum
+#define SVDPRIMMEMethod     PetscEnum
+#define SVDTRLanczosGBidiag PetscEnum
+#define SVDKSVDEigenMethod  PetscEnum
+#define SVDKSVDPolarMethod  PetscEnum
+
+#define SVDCROSS      'cross'
+#define SVDCYCLIC     'cyclic'
+#define SVDLAPACK     'lapack'
+#define SVDLANCZOS    'lanczos'
+#define SVDTRLANCZOS  'trlanczos'
+#define SVDRANDOMIZED 'randomized'
+#define SVDSCALAPACK  'scalapack'
+#define SVDKSVD       'ksvd'
+#define SVDELEMENTAL  'elemental'
+#define SVDPRIMME     'primme'
+
+#endif

--- a/3rd/slepc/linux/include/slepc/finclude/slepcsys.h
+++ b/3rd/slepc/linux/include/slepc/finclude/slepcsys.h
@@ -1,0 +1,22 @@
+!
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!  SLEPc - Scalable Library for Eigenvalue Problem Computations
+!  Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+!
+!  This file is part of SLEPc.
+!  SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+!  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!
+!  Basic include file for Fortran use of the SLEPc package
+!
+#if !defined(SLEPCSYSDEF_H)
+#define SLEPCSYSDEF_H
+
+#include "petsc/finclude/petscmat.h"
+#include "slepcversion.h"
+
+#define SlepcSC type(tSlepcSC)
+
+#define SlepcConvMon PetscFortranAddr
+
+#endif

--- a/3rd/slepc/linux/include/slepc/private/bvimpl.h
+++ b/3rd/slepc/linux/include/slepc/private/bvimpl.h
@@ -1,0 +1,641 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepcbv.h>
+#include <slepc/private/slepcimpl.h>
+
+/* SUBMANSEC = BV */
+
+SLEPC_EXTERN PetscBool BVRegisterAllCalled;
+SLEPC_EXTERN PetscErrorCode BVRegisterAll(void);
+
+SLEPC_EXTERN PetscLogEvent BV_Create,BV_Copy,BV_Mult,BV_MultVec,BV_MultInPlace,BV_Dot,BV_DotVec,BV_Orthogonalize,BV_OrthogonalizeVec,BV_Scale,BV_Norm,BV_NormVec,BV_Normalize,BV_SetRandom,BV_MatMult,BV_MatMultVec,BV_MatProject,BV_SVDAndRank;
+
+typedef struct _BVOps *BVOps;
+
+struct _BVOps {
+  PetscErrorCode (*mult)(BV,PetscScalar,PetscScalar,BV,Mat);
+  PetscErrorCode (*multvec)(BV,PetscScalar,PetscScalar,Vec,PetscScalar*);
+  PetscErrorCode (*multinplace)(BV,Mat,PetscInt,PetscInt);
+  PetscErrorCode (*multinplacetrans)(BV,Mat,PetscInt,PetscInt);
+  PetscErrorCode (*dot)(BV,BV,Mat);
+  PetscErrorCode (*dotvec)(BV,Vec,PetscScalar*);
+  PetscErrorCode (*dotvec_local)(BV,Vec,PetscScalar*);
+  PetscErrorCode (*dotvec_begin)(BV,Vec,PetscScalar*);
+  PetscErrorCode (*dotvec_end)(BV,Vec,PetscScalar*);
+  PetscErrorCode (*scale)(BV,PetscInt,PetscScalar);
+  PetscErrorCode (*norm)(BV,PetscInt,NormType,PetscReal*);
+  PetscErrorCode (*norm_local)(BV,PetscInt,NormType,PetscReal*);
+  PetscErrorCode (*norm_begin)(BV,PetscInt,NormType,PetscReal*);
+  PetscErrorCode (*norm_end)(BV,PetscInt,NormType,PetscReal*);
+  PetscErrorCode (*normalize)(BV,PetscScalar*);
+  PetscErrorCode (*matmult)(BV,Mat,BV);
+  PetscErrorCode (*copy)(BV,BV);
+  PetscErrorCode (*copycolumn)(BV,PetscInt,PetscInt);
+  PetscErrorCode (*resize)(BV,PetscInt,PetscBool);
+  PetscErrorCode (*getcolumn)(BV,PetscInt,Vec*);
+  PetscErrorCode (*restorecolumn)(BV,PetscInt,Vec*);
+  PetscErrorCode (*getarray)(BV,PetscScalar**);
+  PetscErrorCode (*restorearray)(BV,PetscScalar**);
+  PetscErrorCode (*getarrayread)(BV,const PetscScalar**);
+  PetscErrorCode (*restorearrayread)(BV,const PetscScalar**);
+  PetscErrorCode (*restoresplit)(BV,BV*,BV*);
+  PetscErrorCode (*restoresplitrows)(BV,IS,IS,BV*,BV*);
+  PetscErrorCode (*gramschmidt)(BV,PetscInt,Vec,PetscBool*,PetscScalar*,PetscScalar*,PetscReal*,PetscReal*);
+  PetscErrorCode (*getmat)(BV,Mat*);
+  PetscErrorCode (*restoremat)(BV,Mat*);
+  PetscErrorCode (*duplicate)(BV,BV);
+  PetscErrorCode (*create)(BV);
+  PetscErrorCode (*setfromoptions)(BV,PetscOptionItems*);
+  PetscErrorCode (*view)(BV,PetscViewer);
+  PetscErrorCode (*destroy)(BV);
+};
+
+struct _p_BV {
+  PETSCHEADER(struct _BVOps);
+  /*------------------------- User parameters --------------------------*/
+  PetscLayout        map;          /* layout of columns */
+  VecType            vtype;        /* vector type */
+  PetscInt           n,N;          /* dimensions of vectors (local, global) */
+  PetscInt           m;            /* number of vectors */
+  PetscInt           l;            /* number of leading columns */
+  PetscInt           k;            /* number of active columns */
+  PetscInt           nc;           /* number of constraints */
+  PetscInt           ld;           /* leading dimension */
+  BVOrthogType       orthog_type;  /* the method of vector orthogonalization */
+  BVOrthogRefineType orthog_ref;   /* refinement method */
+  PetscReal          orthog_eta;   /* refinement threshold */
+  BVOrthogBlockType  orthog_block; /* the method of block orthogonalization */
+  Mat                matrix;       /* inner product matrix */
+  PetscBool          indef;        /* matrix is indefinite */
+  BVMatMultType      vmm;          /* version of matmult operation */
+  PetscBool          rrandom;      /* reproducible random vectors */
+  PetscReal          deftol;       /* tolerance for BV_SafeSqrt */
+
+  /*---------------------- Cached data and workspace -------------------*/
+  Vec                buffer;       /* buffer vector used in orthogonalization */
+  Mat                Abuffer;      /* auxiliary seqdense matrix that wraps the buffer */
+  Vec                Bx;           /* result of matrix times a vector x */
+  PetscObjectId      xid;          /* object id of vector x */
+  PetscObjectState   xstate;       /* state of vector x */
+  Vec                cv[2];        /* column vectors obtained with BVGetColumn() */
+  PetscInt           ci[2];        /* column indices of obtained vectors */
+  PetscObjectState   st[2];        /* state of obtained vectors */
+  PetscObjectId      id[2];        /* object id of obtained vectors */
+  PetscScalar        *h,*c;        /* orthogonalization coefficients */
+  Vec                omega;        /* signature matrix values for indefinite case */
+  PetscBool          defersfo;     /* deferred call to setfromoptions */
+  BV                 cached;       /* cached BV to store result of matrix times BV */
+  PetscObjectState   bvstate;      /* state of BV when BVApplyMatrixBV() was called */
+  BV                 L,R;          /* BV objects obtained with BVGetSplit/Rows() */
+  PetscObjectState   lstate,rstate;/* state of L and R when BVGetSplit/Rows() was called */
+  PetscInt           lsplit;       /* value of l when BVGetSplit() was called (-1 if BVGetSplitRows()) */
+  PetscInt           issplit;      /* !=0 if BV is from split (1=left, 2=right, -1=top, -2=bottom) */
+  BV                 splitparent;  /* my parent if I am a split BV */
+  PetscRandom        rand;         /* random number generator */
+  Mat                Acreate;      /* matrix given at BVCreateFromMat() */
+  Mat                Aget;         /* matrix returned for BVGetMat() */
+  PetscBool          cuda;         /* true if NVIDIA GPU must be used */
+  PetscBool          hip;          /* true if AMD GPU must be used */
+  PetscBool          sfocalled;    /* setfromoptions has been called */
+  PetscScalar        *work;
+  PetscInt           lwork;
+  void               *data;
+};
+
+/*
+  BV_SafeSqrt - Computes the square root of a scalar value alpha, which is
+  assumed to be z'*B*z. The result is
+    if definite inner product:     res = sqrt(alpha)
+    if indefinite inner product:   res = sgn(alpha)*sqrt(abs(alpha))
+*/
+static inline PetscErrorCode BV_SafeSqrt(BV bv,PetscScalar alpha,PetscReal *res)
+{
+  PetscReal      absal,realp;
+  const char     *msg;
+
+  PetscFunctionBegin;
+  absal = PetscAbsScalar(alpha);
+  realp = PetscRealPart(alpha);
+  if (PetscUnlikely(absal<PETSC_MACHINE_EPSILON)) PetscCall(PetscInfo(bv,"Zero norm %g, either the vector is zero or a semi-inner product is being used\n",(double)absal));
+#if defined(PETSC_USE_COMPLEX)
+  PetscCheck(PetscAbsReal(PetscImaginaryPart(alpha))<bv->deftol || PetscAbsReal(PetscImaginaryPart(alpha))/absal<10*bv->deftol,PetscObjectComm((PetscObject)bv),PETSC_ERR_USER_INPUT,"The inner product is not well defined: nonzero imaginary part %g",(double)PetscImaginaryPart(alpha));
+#endif
+  if (PetscUnlikely(bv->indef)) {
+    *res = (realp<0.0)? -PetscSqrtReal(-realp): PetscSqrtReal(realp);
+  } else {
+    msg = bv->matrix? "The inner product is not well defined: indefinite matrix %g": "Invalid inner product: %g";
+    PetscCheck(realp>-bv->deftol,PetscObjectComm((PetscObject)bv),PETSC_ERR_USER_INPUT,msg,(double)realp);
+    *res = (realp<0.0)? 0.0: PetscSqrtReal(realp);
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+  BV_IPMatMult - Multiply a vector x by the inner-product matrix, cache the
+  result in Bx.
+*/
+static inline PetscErrorCode BV_IPMatMult(BV bv,Vec x)
+{
+  PetscFunctionBegin;
+  if (((PetscObject)x)->id != bv->xid || ((PetscObject)x)->state != bv->xstate) {
+    if (PetscUnlikely(!bv->Bx)) PetscCall(MatCreateVecs(bv->matrix,&bv->Bx,NULL));
+    PetscCall(MatMult(bv->matrix,x,bv->Bx));
+    PetscCall(PetscObjectGetId((PetscObject)x,&bv->xid));
+    PetscCall(VecGetState(x,&bv->xstate));
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+  BV_IPMatMultBV - Multiply BV by the inner-product matrix, cache the
+  result internally in bv->cached.
+*/
+static inline PetscErrorCode BV_IPMatMultBV(BV bv)
+{
+  PetscFunctionBegin;
+  PetscCall(BVGetCachedBV(bv,&bv->cached));
+  if (((PetscObject)bv)->state != bv->bvstate || bv->l != bv->cached->l || bv->k != bv->cached->k) {
+    PetscCall(BVSetActiveColumns(bv->cached,bv->l,bv->k));
+    if (bv->matrix) PetscCall(BVMatMult(bv,bv->matrix,bv->cached));
+    else PetscCall(BVCopy(bv,bv->cached));
+    bv->bvstate = ((PetscObject)bv)->state;
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+  BV_AllocateCoeffs - Allocate orthogonalization coefficients if not done already.
+*/
+static inline PetscErrorCode BV_AllocateCoeffs(BV bv)
+{
+  PetscFunctionBegin;
+  if (!bv->h) PetscCall(PetscMalloc2(bv->nc+bv->m,&bv->h,bv->nc+bv->m,&bv->c));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+  BV_AllocateSignature - Allocate signature coefficients if not done already.
+*/
+static inline PetscErrorCode BV_AllocateSignature(BV bv)
+{
+  PetscFunctionBegin;
+  if (bv->indef && !bv->omega) {
+    if (bv->cuda) {
+#if defined(PETSC_HAVE_CUDA)
+      PetscCall(VecCreateSeqCUDA(PETSC_COMM_SELF,bv->nc+bv->m,&bv->omega));
+#else
+      SETERRQ(PetscObjectComm((PetscObject)bv),PETSC_ERR_PLIB,"Something wrong happened");
+#endif
+    } else if (bv->hip) {
+#if defined(PETSC_HAVE_HIP)
+      PetscCall(VecCreateSeqHIP(PETSC_COMM_SELF,bv->nc+bv->m,&bv->omega));
+#else
+      SETERRQ(PetscObjectComm((PetscObject)bv),PETSC_ERR_PLIB,"Something wrong happened");
+#endif
+    } else PetscCall(VecCreateSeq(PETSC_COMM_SELF,bv->nc+bv->m,&bv->omega));
+    PetscCall(VecSet(bv->omega,1.0));
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+  BV_SetMatrixDiagonal - sets the inner product matrix for BV as a diagonal matrix
+  with the diagonal specified by vector vomega, using the same matrix type as matrix M
+*/
+static inline PetscErrorCode BV_SetMatrixDiagonal(BV bv,Vec vomega,Mat M)
+{
+  Mat      Omega;
+  MatType  Mtype;
+
+  PetscFunctionBegin;
+  PetscCall(MatGetType(M,&Mtype));
+  PetscCall(MatCreate(PetscObjectComm((PetscObject)bv),&Omega));
+  PetscCall(MatSetSizes(Omega,bv->n,bv->n,bv->N,bv->N));
+  PetscCall(MatSetType(Omega,Mtype));
+  PetscCall(MatDiagonalSet(Omega,vomega,INSERT_VALUES));
+  PetscCall(BVSetMatrix(bv,Omega,PETSC_TRUE));
+  PetscCall(MatDestroy(&Omega));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+  BVAvailableVec: First (0) or second (1) vector available for
+  getcolumn operation (or -1 if both vectors already fetched).
+*/
+#define BVAvailableVec (((bv->ci[0]==-bv->nc-1)? 0: (bv->ci[1]==-bv->nc-1)? 1: -1))
+
+/*
+    Macros to test valid BV arguments
+*/
+#if !defined(PETSC_USE_DEBUG)
+
+#define BVCheckSizes(h,arg) do {(void)(h);} while (0)
+#define BVCheckOp(h,arg,op) do {(void)(h);} while (0)
+
+#else
+
+#define BVCheckSizes(h,arg) \
+  do { \
+    PetscCheck((h)->m,PetscObjectComm((PetscObject)(h)),PETSC_ERR_ARG_WRONGSTATE,"BV sizes have not been defined: Parameter #%d",arg); \
+  } while (0)
+
+#define BVCheckOp(h,arg,op) \
+  do { \
+    PetscCheck((h)->ops->op,PetscObjectComm((PetscObject)(h)),PETSC_ERR_SUP,"Operation not implemented in this BV type: Parameter #%d",arg); \
+  } while (0)
+
+#endif
+
+SLEPC_INTERN PetscErrorCode BVView_Vecs(BV,PetscViewer);
+
+SLEPC_INTERN PetscErrorCode BVAllocateWork_Private(BV,PetscInt);
+
+SLEPC_INTERN PetscErrorCode BVMult_BLAS_Private(BV,PetscInt,PetscInt,PetscInt,PetscScalar,const PetscScalar*,PetscInt,const PetscScalar*,PetscInt,PetscScalar,PetscScalar*,PetscInt);
+SLEPC_INTERN PetscErrorCode BVMultVec_BLAS_Private(BV,PetscInt,PetscInt,PetscScalar,const PetscScalar*,PetscInt,const PetscScalar*,PetscScalar,PetscScalar*);
+SLEPC_INTERN PetscErrorCode BVMultInPlace_BLAS_Private(BV,PetscInt,PetscInt,PetscInt,PetscInt,PetscScalar*,PetscInt,const PetscScalar*,PetscInt,PetscBool);
+SLEPC_INTERN PetscErrorCode BVMultInPlace_Vecs_Private(BV,PetscInt,PetscInt,PetscInt,Vec*,const PetscScalar*,PetscBool);
+SLEPC_INTERN PetscErrorCode BVAXPY_BLAS_Private(BV,PetscInt,PetscInt,PetscScalar,const PetscScalar*,PetscInt,PetscScalar,PetscScalar*,PetscInt);
+SLEPC_INTERN PetscErrorCode BVDot_BLAS_Private(BV,PetscInt,PetscInt,PetscInt,const PetscScalar*,PetscInt,const PetscScalar*,PetscInt,PetscScalar*,PetscInt,PetscBool);
+SLEPC_INTERN PetscErrorCode BVDotVec_BLAS_Private(BV,PetscInt,PetscInt,const PetscScalar*,PetscInt,const PetscScalar*,PetscScalar*,PetscBool);
+SLEPC_INTERN PetscErrorCode BVScale_BLAS_Private(BV,PetscInt,PetscScalar*,PetscScalar);
+SLEPC_INTERN PetscErrorCode BVNorm_LAPACK_Private(BV,PetscInt,PetscInt,const PetscScalar*,PetscInt,NormType,PetscReal*,PetscBool);
+SLEPC_INTERN PetscErrorCode BVNormalize_LAPACK_Private(BV,PetscInt,PetscInt,const PetscScalar*,PetscInt,PetscScalar*,PetscBool);
+SLEPC_INTERN PetscErrorCode BVGetMat_Default(BV,Mat*);
+SLEPC_INTERN PetscErrorCode BVRestoreMat_Default(BV,Mat*);
+SLEPC_INTERN PetscErrorCode BVMatCholInv_LAPACK_Private(BV,Mat,Mat);
+SLEPC_INTERN PetscErrorCode BVMatTriInv_LAPACK_Private(BV,Mat,Mat);
+SLEPC_INTERN PetscErrorCode BVMatSVQB_LAPACK_Private(BV,Mat,Mat);
+SLEPC_INTERN PetscErrorCode BVOrthogonalize_LAPACK_TSQR(BV,PetscInt,PetscInt,PetscScalar*,PetscInt,PetscScalar*,PetscInt);
+SLEPC_INTERN PetscErrorCode BVOrthogonalize_LAPACK_TSQR_OnlyR(BV,PetscInt,PetscInt,PetscScalar*,PetscInt,PetscScalar*,PetscInt);
+
+/* reduction operations used in BVOrthogonalize and BVNormalize */
+SLEPC_EXTERN MPI_Op MPIU_TSQR, MPIU_LAPY2;
+SLEPC_EXTERN void MPIAPI SlepcGivensPacked(void*,void*,PetscMPIInt*,MPI_Datatype*);
+SLEPC_EXTERN void MPIAPI SlepcPythag(void*,void*,PetscMPIInt*,MPI_Datatype*);
+
+/*
+   BV_CleanCoefficients_Default - Sets to zero all entries of column j of the bv buffer
+*/
+static inline PetscErrorCode BV_CleanCoefficients_Default(BV bv,PetscInt j,PetscScalar *h)
+{
+  PetscScalar    *hh=h,*a;
+  PetscInt       i;
+
+  PetscFunctionBegin;
+  if (!h) {
+    PetscCall(VecGetArray(bv->buffer,&a));
+    hh = a + j*(bv->nc+bv->m);
+  }
+  for (i=0;i<bv->nc+j;i++) hh[i] = 0.0;
+  if (!h) PetscCall(VecRestoreArray(bv->buffer,&a));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   BV_AddCoefficients_Default - Add the contents of the scratch (0-th column) of the bv buffer
+   into column j of the bv buffer
+*/
+static inline PetscErrorCode BV_AddCoefficients_Default(BV bv,PetscInt j,PetscScalar *h,PetscScalar *c)
+{
+  PetscScalar    *hh=h,*cc=c;
+  PetscInt       i;
+
+  PetscFunctionBegin;
+  if (!h) {
+    PetscCall(VecGetArray(bv->buffer,&cc));
+    hh = cc + j*(bv->nc+bv->m);
+  }
+  for (i=0;i<bv->nc+j;i++) hh[i] += cc[i];
+  if (!h) PetscCall(VecRestoreArray(bv->buffer,&cc));
+  PetscCall(PetscLogFlops(1.0*(bv->nc+j)));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   BV_SetValue_Default - Sets value in row j (counted after the constraints) of column k
+   of the coefficients array
+*/
+static inline PetscErrorCode BV_SetValue_Default(BV bv,PetscInt j,PetscInt k,PetscScalar *h,PetscScalar value)
+{
+  PetscScalar    *hh=h,*a;
+
+  PetscFunctionBegin;
+  if (!h) {
+    PetscCall(VecGetArray(bv->buffer,&a));
+    hh = a + k*(bv->nc+bv->m);
+  }
+  hh[bv->nc+j] = value;
+  if (!h) PetscCall(VecRestoreArray(bv->buffer,&a));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   BV_SquareSum_Default - Returns the value h'*h, where h represents the contents of the
+   coefficients array (up to position j)
+*/
+static inline PetscErrorCode BV_SquareSum_Default(BV bv,PetscInt j,PetscScalar *h,PetscReal *sum)
+{
+  PetscScalar    *hh=h;
+  PetscInt       i;
+
+  PetscFunctionBegin;
+  *sum = 0.0;
+  if (!h) PetscCall(VecGetArray(bv->buffer,&hh));
+  for (i=0;i<bv->nc+j;i++) *sum += PetscRealPart(hh[i]*PetscConj(hh[i]));
+  if (!h) PetscCall(VecRestoreArray(bv->buffer,&hh));
+  PetscCall(PetscLogFlops(2.0*(bv->nc+j)));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   BV_ApplySignature_Default - Computes the pointwise product h*omega, where h represents
+   the contents of the coefficients array (up to position j) and omega is the signature;
+   if inverse=TRUE then the operation is h/omega
+*/
+static inline PetscErrorCode BV_ApplySignature_Default(BV bv,PetscInt j,PetscScalar *h,PetscBool inverse)
+{
+  PetscScalar       *hh=h;
+  PetscInt          i;
+  const PetscScalar *omega;
+
+  PetscFunctionBegin;
+  if (PetscUnlikely(!(bv->nc+j))) PetscFunctionReturn(PETSC_SUCCESS);
+  if (!h) PetscCall(VecGetArray(bv->buffer,&hh));
+  PetscCall(VecGetArrayRead(bv->omega,&omega));
+  if (inverse) for (i=0;i<bv->nc+j;i++) hh[i] /= PetscRealPart(omega[i]);
+  else for (i=0;i<bv->nc+j;i++) hh[i] *= PetscRealPart(omega[i]);
+  PetscCall(VecRestoreArrayRead(bv->omega,&omega));
+  if (!h) PetscCall(VecRestoreArray(bv->buffer,&hh));
+  PetscCall(PetscLogFlops(1.0*(bv->nc+j)));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   BV_SquareRoot_Default - Returns the square root of position j (counted after the constraints)
+   of the coefficients array
+*/
+static inline PetscErrorCode BV_SquareRoot_Default(BV bv,PetscInt j,PetscScalar *h,PetscReal *beta)
+{
+  PetscScalar    *hh=h;
+
+  PetscFunctionBegin;
+  if (!h) PetscCall(VecGetArray(bv->buffer,&hh));
+  PetscCall(BV_SafeSqrt(bv,hh[bv->nc+j],beta));
+  if (!h) PetscCall(VecRestoreArray(bv->buffer,&hh));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   BV_StoreCoefficients_Default - Copy the contents of the coefficients array to an array dest
+   provided by the caller (only values from l to j are copied)
+*/
+static inline PetscErrorCode BV_StoreCoefficients_Default(BV bv,PetscInt j,PetscScalar *h,PetscScalar *dest)
+{
+  PetscScalar    *hh=h,*a;
+  PetscInt       i;
+
+  PetscFunctionBegin;
+  if (!h) {
+    PetscCall(VecGetArray(bv->buffer,&a));
+    hh = a + j*(bv->nc+bv->m);
+  }
+  for (i=bv->l;i<j;i++) dest[i-bv->l] = hh[bv->nc+i];
+  if (!h) PetscCall(VecRestoreArray(bv->buffer,&a));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+  BV_GetEigenvector - retrieves k-th eigenvector from basis vectors V.
+  The argument eigi is the imaginary part of the corresponding eigenvalue.
+*/
+static inline PetscErrorCode BV_GetEigenvector(BV V,PetscInt k,PetscScalar eigi,Vec Vr,Vec Vi)
+{
+  PetscFunctionBegin;
+#if defined(PETSC_USE_COMPLEX)
+  (void)eigi;
+  if (Vr) PetscCall(BVCopyVec(V,k,Vr));
+  if (Vi) PetscCall(VecSet(Vi,0.0));
+#else
+  if (eigi > 0.0) { /* first value of conjugate pair */
+    if (Vr) PetscCall(BVCopyVec(V,k,Vr));
+    if (Vi) PetscCall(BVCopyVec(V,k+1,Vi));
+  } else if (eigi < 0.0) { /* second value of conjugate pair */
+    if (Vr) PetscCall(BVCopyVec(V,k-1,Vr));
+    if (Vi) {
+      PetscCall(BVCopyVec(V,k,Vi));
+      PetscCall(VecScale(Vi,-1.0));
+    }
+  } else { /* real eigenvalue */
+    if (Vr) PetscCall(BVCopyVec(V,k,Vr));
+    if (Vi) PetscCall(VecSet(Vi,0.0));
+  }
+#endif
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   BV_OrthogonalizeColumn_Safe - this is intended for cases where we know that
+   the resulting vector is going to be numerically zero, so normalization or
+   iterative refinement may cause problems in parallel (collective operation
+   not being called by all processes)
+*/
+static inline PetscErrorCode BV_OrthogonalizeColumn_Safe(BV bv,PetscInt j,PetscScalar *H,PetscReal *norm,PetscBool *lindep)
+{
+  BVOrthogRefineType orthog_ref;
+
+  PetscFunctionBegin;
+  PetscCall(PetscInfo(bv,"Orthogonalizing column %" PetscInt_FMT " without refinement\n",j));
+  orthog_ref     = bv->orthog_ref;
+  bv->orthog_ref = BV_ORTHOG_REFINE_NEVER;  /* avoid refinement */
+  PetscCall(BVOrthogonalizeColumn(bv,j,H,NULL,NULL));
+  bv->orthog_ref = orthog_ref;  /* restore refinement setting */
+  if (norm)   *norm  = 0.0;
+  if (lindep) *lindep = PETSC_TRUE;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   BV_SetDefaultLD - set the default value of the leading dimension, based on
+   the local size.
+*/
+static inline PetscErrorCode BV_SetDefaultLD(BV bv,PetscInt nloc)
+{
+  size_t bytes,align;
+
+  PetscFunctionBegin;
+  if (bv->ld) {   /* set by user */
+    PetscCheck(bv->ld>=nloc,PetscObjectComm((PetscObject)bv),PETSC_ERR_USER_INPUT,"The leading dimension %" PetscInt_FMT " should be larger or equal to the local number of rows %" PetscInt_FMT,bv->ld,nloc);
+  } else {
+    align = PetscMax(PETSC_MEMALIGN,16);   /* assume that CUDA requires 16-byte alignment */
+    bytes = (nloc*sizeof(PetscScalar) + align - 1) & ~(align - 1);
+    PetscCall(PetscIntCast(bytes/sizeof(PetscScalar),&bv->ld));
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+#if defined(PETSC_HAVE_CUDA)
+/*
+   BV_MatDenseCUDAGetArrayRead - if Q is MATSEQDENSE it will allocate memory on the
+   GPU and copy the contents; otherwise, calls MatDenseCUDAGetArrayRead()
+*/
+static inline PetscErrorCode BV_MatDenseCUDAGetArrayRead(BV bv,Mat Q,const PetscScalar **d_q)
+{
+  const PetscScalar *q;
+  PetscInt          ldq,mq;
+  PetscCuBLASInt    ldq_=0;
+  PetscBool         matiscuda;
+
+  PetscFunctionBegin;
+  (void)bv; // avoid unused parameter warning
+  PetscCall(MatGetSize(Q,NULL,&mq));
+  PetscCall(MatDenseGetLDA(Q,&ldq));
+  PetscCall(PetscCuBLASIntCast(ldq,&ldq_));
+  PetscCall(PetscObjectTypeCompare((PetscObject)Q,MATSEQDENSECUDA,&matiscuda));
+  if (matiscuda) PetscCall(MatDenseCUDAGetArrayRead(Q,d_q));
+  else {
+    PetscCall(MatDenseGetArrayRead(Q,&q));
+    PetscCallCUDA(cudaMalloc((void**)d_q,ldq*mq*sizeof(PetscScalar)));
+    PetscCallCUDA(cudaMemcpy((void*)*d_q,q,ldq*mq*sizeof(PetscScalar),cudaMemcpyHostToDevice));
+    PetscCall(PetscLogCpuToGpu(ldq*mq*sizeof(PetscScalar)));
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   BV_MatDenseCUDARestoreArrayRead - restores the pointer obtained with BV_MatDenseCUDAGetArrayRead(),
+   freeing the GPU memory in case of MATSEQDENSE
+*/
+static inline PetscErrorCode BV_MatDenseCUDARestoreArrayRead(BV bv,Mat Q,const PetscScalar **d_q)
+{
+  PetscBool matiscuda;
+
+  PetscFunctionBegin;
+  (void)bv; // avoid unused parameter warning
+  PetscCall(PetscObjectTypeCompare((PetscObject)Q,MATSEQDENSECUDA,&matiscuda));
+  if (matiscuda) PetscCall(MatDenseCUDARestoreArrayRead(Q,d_q));
+  else {
+    PetscCall(MatDenseRestoreArrayRead(Q,NULL));
+    PetscCallCUDA(cudaFree((void*)*d_q));
+    *d_q = NULL;
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+SLEPC_INTERN PetscErrorCode BVMult_BLAS_CUDA(BV,PetscInt,PetscInt,PetscInt,PetscScalar,const PetscScalar*,PetscInt,const PetscScalar*,PetscInt,PetscScalar,PetscScalar*,PetscInt);
+SLEPC_INTERN PetscErrorCode BVMultVec_BLAS_CUDA(BV,PetscInt,PetscInt,PetscScalar,const PetscScalar*,PetscInt,const PetscScalar*,PetscScalar,PetscScalar*);
+SLEPC_INTERN PetscErrorCode BVMultInPlace_BLAS_CUDA(BV,PetscInt,PetscInt,PetscInt,PetscInt,PetscScalar*,PetscInt,const PetscScalar*,PetscInt,PetscBool);
+SLEPC_INTERN PetscErrorCode BVAXPY_BLAS_CUDA(BV,PetscInt,PetscInt,PetscScalar,const PetscScalar*,PetscInt,PetscScalar,PetscScalar*,PetscInt);
+SLEPC_INTERN PetscErrorCode BVDot_BLAS_CUDA(BV,PetscInt,PetscInt,PetscInt,const PetscScalar*,PetscInt,const PetscScalar*,PetscInt,PetscScalar*,PetscInt,PetscBool);
+SLEPC_INTERN PetscErrorCode BVDotVec_BLAS_CUDA(BV,PetscInt,PetscInt,const PetscScalar*,PetscInt,const PetscScalar*,PetscScalar*,PetscBool);
+SLEPC_INTERN PetscErrorCode BVScale_BLAS_CUDA(BV,PetscInt,PetscScalar*,PetscScalar);
+SLEPC_INTERN PetscErrorCode BVNorm_BLAS_CUDA(BV,PetscInt,const PetscScalar*,PetscReal*);
+SLEPC_INTERN PetscErrorCode BVNormalize_BLAS_CUDA(BV,PetscInt,PetscInt,PetscScalar*,PetscInt,PetscScalar*);
+
+SLEPC_INTERN PetscErrorCode BV_CleanCoefficients_CUDA(BV,PetscInt,PetscScalar*);
+SLEPC_INTERN PetscErrorCode BV_AddCoefficients_CUDA(BV,PetscInt,PetscScalar*,PetscScalar*);
+SLEPC_INTERN PetscErrorCode BV_SetValue_CUDA(BV,PetscInt,PetscInt,PetscScalar*,PetscScalar);
+SLEPC_INTERN PetscErrorCode BV_SquareSum_CUDA(BV,PetscInt,PetscScalar*,PetscReal*);
+SLEPC_INTERN PetscErrorCode BV_ApplySignature_CUDA(BV,PetscInt,PetscScalar*,PetscBool);
+SLEPC_INTERN PetscErrorCode BV_SquareRoot_CUDA(BV,PetscInt,PetscScalar*,PetscReal*);
+SLEPC_INTERN PetscErrorCode BV_StoreCoefficients_CUDA(BV,PetscInt,PetscScalar*,PetscScalar*);
+#define BV_CleanCoefficients(a,b,c)   ((a)->cuda?BV_CleanCoefficients_CUDA:BV_CleanCoefficients_Default)((a),(b),(c))
+#define BV_AddCoefficients(a,b,c,d)   ((a)->cuda?BV_AddCoefficients_CUDA:BV_AddCoefficients_Default)((a),(b),(c),(d))
+#define BV_SetValue(a,b,c,d,e)        ((a)->cuda?BV_SetValue_CUDA:BV_SetValue_Default)((a),(b),(c),(d),(e))
+#define BV_SquareSum(a,b,c,d)         ((a)->cuda?BV_SquareSum_CUDA:BV_SquareSum_Default)((a),(b),(c),(d))
+#define BV_ApplySignature(a,b,c,d)    ((a)->cuda?BV_ApplySignature_CUDA:BV_ApplySignature_Default)((a),(b),(c),(d))
+#define BV_SquareRoot(a,b,c,d)        ((a)->cuda?BV_SquareRoot_CUDA:BV_SquareRoot_Default)((a),(b),(c),(d))
+#define BV_StoreCoefficients(a,b,c,d) ((a)->cuda?BV_StoreCoefficients_CUDA:BV_StoreCoefficients_Default)((a),(b),(c),(d))
+
+#elif defined(PETSC_HAVE_HIP)
+#include <petscdevice_cupm.h>
+/*
+   BV_MatDenseHIPGetArrayRead - if Q is MATSEQDENSE it will allocate memory on the
+   GPU and copy the contents; otherwise, calls MatDenseHIPGetArrayRead()
+*/
+static inline PetscErrorCode BV_MatDenseHIPGetArrayRead(BV bv,Mat Q,const PetscScalar **d_q)
+{
+  const PetscScalar *q;
+  PetscInt          ldq,mq;
+  PetscCuBLASInt    ldq_=0;
+  PetscBool         matiship;
+
+  PetscFunctionBegin;
+  (void)bv; // avoid unused parameter warning
+  PetscCall(MatGetSize(Q,NULL,&mq));
+  PetscCall(MatDenseGetLDA(Q,&ldq));
+  PetscCall(PetscHipBLASIntCast(ldq,&ldq_));
+  PetscCall(PetscObjectTypeCompare((PetscObject)Q,MATSEQDENSEHIP,&matiship));
+  if (matiship) PetscCall(MatDenseHIPGetArrayRead(Q,d_q));
+  else {
+    PetscCall(MatDenseGetArrayRead(Q,&q));
+    PetscCallHIP(hipMalloc((void**)d_q,ldq*mq*sizeof(PetscScalar)));
+    PetscCallHIP(hipMemcpy((void*)*d_q,q,ldq*mq*sizeof(PetscScalar),hipMemcpyHostToDevice));
+    PetscCall(PetscLogCpuToGpu(ldq*mq*sizeof(PetscScalar)));
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   BV_MatDenseHIPRestoreArrayRead - restores the pointer obtained with BV_MatDenseHIPGetArrayRead(),
+   freeing the GPU memory in case of MATSEQDENSE
+*/
+static inline PetscErrorCode BV_MatDenseHIPRestoreArrayRead(BV bv,Mat Q,const PetscScalar **d_q)
+{
+  PetscBool matiship;
+
+  PetscFunctionBegin;
+  (void)bv; // avoid unused parameter warning
+  PetscCall(PetscObjectTypeCompare((PetscObject)Q,MATSEQDENSEHIP,&matiship));
+  if (matiship) PetscCall(MatDenseHIPRestoreArrayRead(Q,d_q));
+  else {
+    PetscCall(MatDenseRestoreArrayRead(Q,NULL));
+    PetscCallHIP(hipFree((void*)*d_q));
+    *d_q = NULL;
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+SLEPC_INTERN PetscErrorCode BVMult_BLAS_HIP(BV,PetscInt,PetscInt,PetscInt,PetscScalar,const PetscScalar*,PetscInt,const PetscScalar*,PetscInt,PetscScalar,PetscScalar*,PetscInt);
+SLEPC_INTERN PetscErrorCode BVMultVec_BLAS_HIP(BV,PetscInt,PetscInt,PetscScalar,const PetscScalar*,PetscInt,const PetscScalar*,PetscScalar,PetscScalar*);
+SLEPC_INTERN PetscErrorCode BVMultInPlace_BLAS_HIP(BV,PetscInt,PetscInt,PetscInt,PetscInt,PetscScalar*,PetscInt,const PetscScalar*,PetscInt,PetscBool);
+SLEPC_INTERN PetscErrorCode BVAXPY_BLAS_HIP(BV,PetscInt,PetscInt,PetscScalar,const PetscScalar*,PetscInt,PetscScalar,PetscScalar*,PetscInt);
+SLEPC_INTERN PetscErrorCode BVDot_BLAS_HIP(BV,PetscInt,PetscInt,PetscInt,const PetscScalar*,PetscInt,const PetscScalar*,PetscInt,PetscScalar*,PetscInt,PetscBool);
+SLEPC_INTERN PetscErrorCode BVDotVec_BLAS_HIP(BV,PetscInt,PetscInt,const PetscScalar*,PetscInt,const PetscScalar*,PetscScalar*,PetscBool);
+SLEPC_INTERN PetscErrorCode BVScale_BLAS_HIP(BV,PetscInt,PetscScalar*,PetscScalar);
+SLEPC_INTERN PetscErrorCode BVNorm_BLAS_HIP(BV,PetscInt,const PetscScalar*,PetscReal*);
+SLEPC_INTERN PetscErrorCode BVNormalize_BLAS_HIP(BV,PetscInt,PetscInt,PetscScalar*,PetscInt,PetscScalar*);
+
+SLEPC_INTERN PetscErrorCode BV_CleanCoefficients_HIP(BV,PetscInt,PetscScalar*);
+SLEPC_INTERN PetscErrorCode BV_AddCoefficients_HIP(BV,PetscInt,PetscScalar*,PetscScalar*);
+SLEPC_INTERN PetscErrorCode BV_SetValue_HIP(BV,PetscInt,PetscInt,PetscScalar*,PetscScalar);
+SLEPC_INTERN PetscErrorCode BV_SquareSum_HIP(BV,PetscInt,PetscScalar*,PetscReal*);
+SLEPC_INTERN PetscErrorCode BV_ApplySignature_HIP(BV,PetscInt,PetscScalar*,PetscBool);
+SLEPC_INTERN PetscErrorCode BV_SquareRoot_HIP(BV,PetscInt,PetscScalar*,PetscReal*);
+SLEPC_INTERN PetscErrorCode BV_StoreCoefficients_HIP(BV,PetscInt,PetscScalar*,PetscScalar*);
+#define BV_CleanCoefficients(a,b,c)   ((a)->hip?BV_CleanCoefficients_HIP:BV_CleanCoefficients_Default)((a),(b),(c))
+#define BV_AddCoefficients(a,b,c,d)   ((a)->hip?BV_AddCoefficients_HIP:BV_AddCoefficients_Default)((a),(b),(c),(d))
+#define BV_SetValue(a,b,c,d,e)        ((a)->hip?BV_SetValue_HIP:BV_SetValue_Default)((a),(b),(c),(d),(e))
+#define BV_SquareSum(a,b,c,d)         ((a)->hip?BV_SquareSum_HIP:BV_SquareSum_Default)((a),(b),(c),(d))
+#define BV_ApplySignature(a,b,c,d)    ((a)->hip?BV_ApplySignature_HIP:BV_ApplySignature_Default)((a),(b),(c),(d))
+#define BV_SquareRoot(a,b,c,d)        ((a)->hip?BV_SquareRoot_HIP:BV_SquareRoot_Default)((a),(b),(c),(d))
+#define BV_StoreCoefficients(a,b,c,d) ((a)->hip?BV_StoreCoefficients_HIP:BV_StoreCoefficients_Default)((a),(b),(c),(d))
+
+#else /* CPU */
+#define BV_CleanCoefficients(a,b,c)   BV_CleanCoefficients_Default((a),(b),(c))
+#define BV_AddCoefficients(a,b,c,d)   BV_AddCoefficients_Default((a),(b),(c),(d))
+#define BV_SetValue(a,b,c,d,e)        BV_SetValue_Default((a),(b),(c),(d),(e))
+#define BV_SquareSum(a,b,c,d)         BV_SquareSum_Default((a),(b),(c),(d))
+#define BV_ApplySignature(a,b,c,d)    BV_ApplySignature_Default((a),(b),(c),(d))
+#define BV_SquareRoot(a,b,c,d)        BV_SquareRoot_Default((a),(b),(c),(d))
+#define BV_StoreCoefficients(a,b,c,d) BV_StoreCoefficients_Default((a),(b),(c),(d))
+#endif /* PETSC_HAVE_CUDA */

--- a/3rd/slepc/linux/include/slepc/private/dsimpl.h
+++ b/3rd/slepc/linux/include/slepc/private/dsimpl.h
@@ -1,0 +1,138 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepcds.h>
+#include <slepc/private/slepcimpl.h>
+
+/* SUBMANSEC = DS */
+
+SLEPC_EXTERN PetscBool DSRegisterAllCalled;
+SLEPC_EXTERN PetscErrorCode DSRegisterAll(void);
+SLEPC_EXTERN PetscLogEvent DS_Solve,DS_Vectors,DS_Synchronize,DS_Other;
+SLEPC_INTERN const char *DSMatName[];
+
+typedef struct _DSOps *DSOps;
+
+struct _DSOps {
+  PetscErrorCode (*allocate)(DS,PetscInt);
+  PetscErrorCode (*setfromoptions)(DS,PetscOptionItems*);
+  PetscErrorCode (*view)(DS,PetscViewer);
+  PetscErrorCode (*vectors)(DS,DSMatType,PetscInt*,PetscReal*);
+  PetscErrorCode (*solve[DS_MAX_SOLVE])(DS,PetscScalar*,PetscScalar*);
+  PetscErrorCode (*sort)(DS,PetscScalar*,PetscScalar*,PetscScalar*,PetscScalar*,PetscInt*);
+  PetscErrorCode (*sortperm)(DS,PetscInt*,PetscScalar*,PetscScalar*);
+  PetscErrorCode (*gettruncatesize)(DS,PetscInt,PetscInt,PetscInt*);
+  PetscErrorCode (*truncate)(DS,PetscInt,PetscBool);
+  PetscErrorCode (*update)(DS);
+  PetscErrorCode (*cond)(DS,PetscReal*);
+  PetscErrorCode (*transharm)(DS,PetscScalar,PetscReal,PetscBool,PetscScalar*,PetscReal*);
+  PetscErrorCode (*transrks)(DS,PetscScalar);
+  PetscErrorCode (*destroy)(DS);
+  PetscErrorCode (*matgetsize)(DS,DSMatType,PetscInt*,PetscInt*);
+  PetscErrorCode (*hermitian)(DS,DSMatType,PetscBool*);
+  PetscErrorCode (*synchronize)(DS,PetscScalar*,PetscScalar*);
+  PetscErrorCode (*setcompact)(DS,PetscBool);
+};
+
+struct _p_DS {
+  PETSCHEADER(struct _DSOps);
+  /*------------------------- User parameters --------------------------*/
+  DSStateType    state;              /* the current state */
+  PetscInt       method;             /* identifies the variant to be used */
+  PetscBool      compact;            /* whether the matrices are stored in compact form */
+  PetscBool      refined;            /* get refined vectors instead of regular vectors */
+  PetscBool      extrarow;           /* assume the matrix dimension is (n+1) x n */
+  PetscInt       ld;                 /* leading dimension */
+  PetscInt       l;                  /* number of locked (inactive) leading columns */
+  PetscInt       n;                  /* current dimension */
+  PetscInt       k;                  /* intermediate dimension (e.g. position of arrow) */
+  PetscInt       t;                  /* length of decomposition when it was truncated */
+  PetscInt       bs;                 /* block size */
+  SlepcSC        sc;                 /* sorting criterion */
+  DSParallelType pmode;              /* parallel mode (redundant, synchronized, distributed) */
+
+  /*----------------- Status variables and working data ----------------*/
+  Mat            omat[DS_NUM_MAT];   /* the matrices (PETSc object) */
+  PetscInt       *perm;              /* permutation */
+  void           *data;              /* placeholder for solver-specific stuff */
+  PetscBool      scset;              /* the sc was provided by the user */
+  PetscScalar    *work;
+  PetscReal      *rwork;
+  PetscBLASInt   *iwork;
+  PetscInt       lwork,lrwork,liwork;
+};
+
+/*
+    Macros to test valid DS arguments
+*/
+#if !defined(PETSC_USE_DEBUG)
+
+#define DSCheckAlloc(h,arg) do {(void)(h);} while (0)
+#define DSCheckSolved(h,arg) do {(void)(h);} while (0)
+#define DSCheckValidMat(ds,m,arg) do {(void)(ds);} while (0)
+#define DSCheckValidMatReal(ds,m,arg) do {(void)(ds);} while (0)
+
+#else
+
+#define DSCheckAlloc(h,arg) \
+  do { \
+    PetscCheck((h)->ld,PetscObjectComm((PetscObject)(h)),PETSC_ERR_ARG_WRONGSTATE,"Must call DSAllocate() first: Parameter #%d",arg); \
+  } while (0)
+
+#define DSCheckSolved(h,arg) \
+  do { \
+    PetscCheck((h)->state>=DS_STATE_CONDENSED,PetscObjectComm((PetscObject)(h)),PETSC_ERR_ARG_WRONGSTATE,"Must call DSSolve() first: Parameter #%d",arg); \
+  } while (0)
+
+#define DSCheckValidMat(ds,m,arg) \
+  do { \
+    PetscCheck((m)<DS_NUM_MAT,PetscObjectComm((PetscObject)(ds)),PETSC_ERR_ARG_WRONG,"Invalid matrix: Parameter #%d",arg); \
+    PetscCheck((ds)->omat[m],PetscObjectComm((PetscObject)(ds)),PETSC_ERR_ARG_WRONGSTATE,"Requested matrix was not created in this DS: Parameter #%d",arg); \
+  } while (0)
+
+#define DSCheckValidMatReal(ds,m,arg) \
+  do { \
+    PetscCheck((m)==DS_MAT_T || (m)==DS_MAT_D,PetscObjectComm((PetscObject)(ds)),PETSC_ERR_ARG_WRONG,"Invalid matrix, can only be used for T and D: Parameter #%d",arg); \
+    PetscCheck((ds)->omat[m],PetscObjectComm((PetscObject)(ds)),PETSC_ERR_ARG_WRONGSTATE,"Requested matrix was not created in this DS: Parameter #%d",arg); \
+  } while (0)
+
+#endif
+
+SLEPC_INTERN PetscErrorCode DSAllocateMat_Private(DS,DSMatType);
+SLEPC_INTERN PetscErrorCode DSAllocateWork_Private(DS,PetscInt,PetscInt,PetscInt);
+SLEPC_INTERN PetscErrorCode DSSortEigenvalues_Private(DS,PetscScalar*,PetscScalar*,PetscInt*,PetscBool);
+SLEPC_INTERN PetscErrorCode DSSortEigenvaluesReal_Private(DS,PetscReal*,PetscInt*);
+SLEPC_INTERN PetscErrorCode DSPermuteColumns_Private(DS,PetscInt,PetscInt,PetscInt,DSMatType,PetscInt*);
+SLEPC_INTERN PetscErrorCode DSPermuteColumnsTwo_Private(DS,PetscInt,PetscInt,PetscInt,DSMatType,DSMatType,PetscInt*);
+SLEPC_INTERN PetscErrorCode DSPermuteRows_Private(DS,PetscInt,PetscInt,PetscInt,DSMatType,PetscInt*);
+SLEPC_INTERN PetscErrorCode DSPermuteBoth_Private(DS,PetscInt,PetscInt,PetscInt,PetscInt,DSMatType,DSMatType,PetscInt*);
+SLEPC_INTERN PetscErrorCode DSGetTruncateSize_Default(DS,PetscInt,PetscInt,PetscInt*);
+
+SLEPC_INTERN PetscErrorCode DSGHIEPOrthogEigenv(DS,DSMatType,PetscScalar*,PetscScalar*,PetscBool);
+SLEPC_INTERN PetscErrorCode DSPseudoOrthog_HR(PetscInt*,PetscScalar*,PetscInt,PetscReal*,PetscScalar*,PetscInt,PetscBLASInt*,PetscBLASInt*,PetscBool*,PetscScalar*);
+SLEPC_INTERN PetscErrorCode DSGHIEPComplexEigs(DS,PetscInt,PetscInt,PetscScalar*,PetscScalar*);
+SLEPC_INTERN PetscErrorCode DSGHIEPInverseIteration(DS,PetscScalar*,PetscScalar*);
+SLEPC_INTERN PetscErrorCode DSIntermediate_GHIEP(DS);
+SLEPC_INTERN PetscErrorCode DSSwitchFormat_GHIEP(DS,PetscBool);
+SLEPC_INTERN PetscErrorCode DSGHIEPRealBlocks(DS);
+SLEPC_INTERN PetscErrorCode DSSolve_GHIEP_HZ(DS,PetscScalar*,PetscScalar*);
+SLEPC_INTERN PetscErrorCode DSArrowTridiag(PetscBLASInt,PetscReal*,PetscReal*,PetscScalar*,PetscBLASInt);
+
+SLEPC_INTERN PetscErrorCode DSSolve_NHEP_Private(DS,DSMatType,DSMatType,PetscScalar*,PetscScalar*);
+SLEPC_INTERN PetscErrorCode DSSort_NHEP_Total(DS,DSMatType,DSMatType,PetscScalar*,PetscScalar*);
+SLEPC_INTERN PetscErrorCode DSSortWithPermutation_NHEP_Private(DS,PetscInt*,DSMatType,DSMatType,PetscScalar*,PetscScalar*);
+
+SLEPC_INTERN PetscErrorCode BDC_dibtdc_(const char*,PetscBLASInt,PetscBLASInt,PetscBLASInt*,PetscReal*,PetscBLASInt,PetscBLASInt,PetscReal*,PetscBLASInt*,PetscBLASInt,PetscBLASInt,PetscReal,PetscReal*,PetscReal*,PetscBLASInt,PetscReal*,PetscBLASInt,PetscBLASInt*,PetscBLASInt,PetscBLASInt*,PetscBLASInt);
+SLEPC_INTERN PetscErrorCode BDC_dlaed3m_(const char*,const char*,PetscBLASInt,PetscBLASInt,PetscBLASInt,PetscReal*,PetscReal*,PetscBLASInt,PetscReal,PetscReal*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscReal*,PetscBLASInt*,PetscBLASInt,PetscBLASInt);
+SLEPC_INTERN PetscErrorCode BDC_dmerg2_(const char*,PetscBLASInt,PetscBLASInt,PetscReal*,PetscReal*,PetscBLASInt,PetscBLASInt*,PetscReal*,PetscReal*,PetscBLASInt,PetscReal*,PetscBLASInt,PetscBLASInt,PetscReal*,PetscBLASInt,PetscBLASInt*,PetscReal,PetscBLASInt*,PetscBLASInt);
+SLEPC_INTERN PetscErrorCode BDC_dsbtdc_(const char*,const char*,PetscBLASInt,PetscBLASInt,PetscBLASInt*,PetscReal*,PetscBLASInt,PetscBLASInt,PetscReal*,PetscBLASInt,PetscBLASInt,PetscReal,PetscReal,PetscReal,PetscReal*,PetscReal*,PetscBLASInt,PetscReal*,PetscBLASInt,PetscBLASInt*,PetscBLASInt,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt,PetscBLASInt);
+SLEPC_INTERN PetscErrorCode BDC_dsrtdf_(PetscBLASInt*,PetscBLASInt,PetscBLASInt,PetscReal*,PetscReal*,PetscBLASInt,PetscBLASInt*,PetscReal*,PetscReal*,PetscReal*,PetscReal*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscReal,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*);

--- a/3rd/slepc/linux/include/slepc/private/epsimpl.h
+++ b/3rd/slepc/linux/include/slepc/private/epsimpl.h
@@ -1,0 +1,438 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepceps.h>
+#include <slepc/private/bvimpl.h>
+
+/* SUBMANSEC = EPS */
+
+SLEPC_EXTERN PetscBool EPSRegisterAllCalled;
+SLEPC_EXTERN PetscBool EPSMonitorRegisterAllCalled;
+SLEPC_EXTERN PetscErrorCode EPSRegisterAll(void);
+SLEPC_EXTERN PetscErrorCode EPSMonitorRegisterAll(void);
+SLEPC_EXTERN PetscLogEvent EPS_SetUp,EPS_Solve,EPS_CISS_SVD;
+
+typedef struct _EPSOps *EPSOps;
+
+struct _EPSOps {
+  PetscErrorCode (*solve)(EPS);
+  PetscErrorCode (*setup)(EPS);
+  PetscErrorCode (*setupsort)(EPS);
+  PetscErrorCode (*setfromoptions)(EPS,PetscOptionItems*);
+  PetscErrorCode (*publishoptions)(EPS);
+  PetscErrorCode (*destroy)(EPS);
+  PetscErrorCode (*reset)(EPS);
+  PetscErrorCode (*view)(EPS,PetscViewer);
+  PetscErrorCode (*backtransform)(EPS);
+  PetscErrorCode (*computevectors)(EPS);
+  PetscErrorCode (*setdefaultst)(EPS);
+  PetscErrorCode (*setdstype)(EPS);
+};
+
+/*
+   Maximum number of monitors you can run with a single EPS
+*/
+#define MAXEPSMONITORS 5
+
+/*
+   The solution process goes through several states
+*/
+typedef enum { EPS_STATE_INITIAL,
+               EPS_STATE_SETUP,
+               EPS_STATE_SOLVED,
+               EPS_STATE_EIGENVECTORS } EPSStateType;
+
+/*
+   To classify the different solvers into categories
+*/
+typedef enum { EPS_CATEGORY_KRYLOV,      /* Krylov solver: relies on STApply and STBackTransform (same as OTHER) */
+               EPS_CATEGORY_PRECOND,     /* Preconditioned solver: uses ST only to manage preconditioner */
+               EPS_CATEGORY_CONTOUR,     /* Contour integral: ST used to solve linear systems at integration points */
+               EPS_CATEGORY_OTHER } EPSSolverType;
+
+/*
+   To check for unsupported features at EPSSetUp_XXX()
+*/
+typedef enum { EPS_FEATURE_BALANCE=1,       /* balancing */
+               EPS_FEATURE_ARBITRARY=2,     /* arbitrary selection of eigepairs */
+               EPS_FEATURE_REGION=4,        /* nontrivial region for filtering */
+               EPS_FEATURE_EXTRACTION=8,    /* extraction technique different from Ritz */
+               EPS_FEATURE_CONVERGENCE=16,  /* convergence test selected by user */
+               EPS_FEATURE_STOPPING=32,     /* stopping test */
+               EPS_FEATURE_TWOSIDED=64      /* two-sided variant */
+             } EPSFeatureType;
+
+/*
+   Defines the EPS data structure
+*/
+struct _p_EPS {
+  PETSCHEADER(struct _EPSOps);
+  /*------------------------- User parameters ---------------------------*/
+  PetscInt       max_it;           /* maximum number of iterations */
+  PetscInt       nev;              /* number of eigenvalues to compute */
+  PetscInt       ncv;              /* number of basis vectors */
+  PetscInt       mpd;              /* maximum dimension of projected problem */
+  PetscInt       nini,ninil;       /* number of initial vectors (negative means not copied yet) */
+  PetscInt       nds;              /* number of basis vectors of deflation space */
+  PetscScalar    target;           /* target value */
+  PetscReal      tol;              /* tolerance */
+  EPSConv        conv;             /* convergence test */
+  EPSStop        stop;             /* stopping test */
+  EPSWhich       which;            /* which part of the spectrum to be sought */
+  PetscReal      inta,intb;        /* interval [a,b] for spectrum slicing */
+  EPSProblemType problem_type;     /* which kind of problem to be solved */
+  EPSExtraction  extraction;       /* which kind of extraction to be applied */
+  EPSBalance     balance;          /* the balancing method */
+  PetscInt       balance_its;      /* number of iterations of the balancing method */
+  PetscReal      balance_cutoff;   /* cutoff value for balancing */
+  PetscBool      trueres;          /* whether the true residual norm must be computed */
+  PetscBool      trackall;         /* whether all the residuals must be computed */
+  PetscBool      purify;           /* whether eigenvectors need to be purified */
+  PetscBool      twosided;         /* whether to compute left eigenvectors (two-sided solver) */
+
+  /*-------------- User-provided functions and contexts -----------------*/
+  EPSConvergenceTestFn      *converged;
+  EPSConvergenceTestFn      *convergeduser;
+  PetscErrorCode            (*convergeddestroy)(void*);
+  EPSStoppingTestFn         *stopping;
+  EPSStoppingTestFn         *stoppinguser;
+  PetscErrorCode            (*stoppingdestroy)(void*);
+  SlepcArbitrarySelectionFn *arbitrary;
+  void           *convergedctx;
+  void           *stoppingctx;
+  void           *arbitraryctx;
+  PetscErrorCode (*monitor[MAXEPSMONITORS])(EPS,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,void*);
+  PetscErrorCode (*monitordestroy[MAXEPSMONITORS])(void**);
+  void           *monitorcontext[MAXEPSMONITORS];
+  PetscInt       numbermonitors;
+
+  /*----------------- Child objects and working data -------------------*/
+  ST             st;               /* spectral transformation object */
+  DS             ds;               /* direct solver object */
+  BV             V;                /* set of basis vectors and computed eigenvectors */
+  BV             W;                /* left basis vectors (if left eigenvectors requested) */
+  RG             rg;               /* optional region for filtering */
+  SlepcSC        sc;               /* sorting criterion data */
+  Vec            D;                /* diagonal matrix for balancing */
+  Vec            *IS,*ISL;         /* references to user-provided initial spaces */
+  Vec            *defl;            /* references to user-provided deflation space */
+  PetscScalar    *eigr,*eigi;      /* real and imaginary parts of eigenvalues */
+  PetscReal      *errest;          /* error estimates */
+  PetscScalar    *rr,*ri;          /* values computed by user's arbitrary selection function */
+  PetscInt       *perm;            /* permutation for eigenvalue ordering */
+  PetscInt       nwork;            /* number of work vectors */
+  Vec            *work;            /* work vectors */
+  void           *data;            /* placeholder for solver-specific stuff */
+
+  /* ----------------------- Status variables --------------------------*/
+  EPSStateType   state;            /* initial -> setup -> solved -> eigenvectors */
+  EPSSolverType  categ;            /* solver category */
+  PetscInt       nconv;            /* number of converged eigenvalues */
+  PetscInt       its;              /* number of iterations so far computed */
+  PetscInt       n,nloc;           /* problem dimensions (global, local) */
+  PetscReal      nrma,nrmb;        /* computed matrix norms */
+  PetscBool      useds;            /* whether the solver uses the DS object or not */
+  PetscBool      isgeneralized;
+  PetscBool      ispositive;
+  PetscBool      ishermitian;
+  PetscBool      isstructured;
+  EPSConvergedReason reason;
+};
+
+/*
+    Macros to test valid EPS arguments
+*/
+#if !defined(PETSC_USE_DEBUG)
+
+#define EPSCheckSolved(h,arg) do {(void)(h);} while (0)
+
+#else
+
+#define EPSCheckSolved(h,arg) \
+  do { \
+    PetscCheck((h)->state>=EPS_STATE_SOLVED,PetscObjectComm((PetscObject)(h)),PETSC_ERR_ARG_WRONGSTATE,"Must call EPSSolve() first: Parameter #%d",arg); \
+  } while (0)
+
+#endif
+
+/*
+    Macros to check settings at EPSSetUp()
+*/
+
+/* EPSCheckHermitianDefinite: the problem is HEP or GHEP */
+#define EPSCheckHermitianDefiniteCondition(eps,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscCheck((eps)->ishermitian,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s cannot be used for non-%s problems",((PetscObject)(eps))->type_name,(msg),SLEPC_STRING_HERMITIAN); \
+      PetscCheck(!(eps)->isgeneralized || (eps)->ispositive,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s requires that the problem is %s-definite",((PetscObject)(eps))->type_name,(msg),SLEPC_STRING_HERMITIAN); \
+    } \
+  } while (0)
+#define EPSCheckHermitianDefinite(eps) EPSCheckHermitianDefiniteCondition(eps,PETSC_TRUE,"")
+
+/* EPSCheckHermitian: the problem is HEP, GHEP, or GHIEP */
+#define EPSCheckHermitianCondition(eps,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscCheck((eps)->ishermitian,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s cannot be used for non-%s problems",((PetscObject)(eps))->type_name,(msg),SLEPC_STRING_HERMITIAN); \
+    } \
+  } while (0)
+#define EPSCheckHermitian(eps) EPSCheckHermitianCondition(eps,PETSC_TRUE,"")
+
+/* EPSCheckDefinite: the problem is not GHIEP */
+#define EPSCheckDefiniteCondition(eps,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscCheck(!(eps)->isgeneralized || !(eps)->ishermitian || (eps)->ispositive,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s cannot be used for %s-indefinite problems",((PetscObject)(eps))->type_name,(msg),SLEPC_STRING_HERMITIAN); \
+    } \
+  } while (0)
+#define EPSCheckDefinite(eps) EPSCheckDefiniteCondition(eps,PETSC_TRUE,"")
+
+/* EPSCheckStandard: the problem is HEP or NHEP */
+#define EPSCheckStandardCondition(eps,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscCheck(!(eps)->isgeneralized,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s cannot be used for generalized problems",((PetscObject)(eps))->type_name,(msg)); \
+    } \
+  } while (0)
+#define EPSCheckStandard(eps) EPSCheckStandardCondition(eps,PETSC_TRUE,"")
+
+/* EPSCheckNotStructured: the problem is not structured */
+#define EPSCheckNotStructuredCondition(eps,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscCheck(!(eps)->isstructured,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s does not provide support for structured eigenproblems",((PetscObject)(eps))->type_name,(msg)); \
+    } \
+  } while (0)
+#define EPSCheckNotStructured(eps) EPSCheckNotStructuredCondition(eps,PETSC_TRUE,"")
+
+/* EPSCheckSinvert: shift-and-invert ST */
+#define EPSCheckSinvertCondition(eps,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscBool __flg; \
+      PetscCall(PetscObjectTypeCompare((PetscObject)(eps)->st,STSINVERT,&__flg)); \
+      PetscCheck(__flg,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s requires a shift-and-invert spectral transform",((PetscObject)(eps))->type_name,(msg)); \
+    } \
+  } while (0)
+#define EPSCheckSinvert(eps) EPSCheckSinvertCondition(eps,PETSC_TRUE,"")
+
+/* EPSCheckSinvertCayley: shift-and-invert or Cayley ST */
+#define EPSCheckSinvertCayleyCondition(eps,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscBool __flg; \
+      PetscCall(PetscObjectTypeCompareAny((PetscObject)(eps)->st,&__flg,STSINVERT,STCAYLEY,"")); \
+      PetscCheck(__flg,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s requires shift-and-invert or Cayley transform",((PetscObject)(eps))->type_name,(msg)); \
+    } \
+  } while (0)
+#define EPSCheckSinvertCayley(eps) EPSCheckSinvertCayleyCondition(eps,PETSC_TRUE,"")
+
+/* Check for unsupported features */
+#define EPSCheckUnsupportedCondition(eps,mask,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscCheck(!((mask) & EPS_FEATURE_BALANCE) || (eps)->balance==EPS_BALANCE_NONE,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s does not support balancing",((PetscObject)(eps))->type_name,(msg)); \
+      PetscCheck(!((mask) & EPS_FEATURE_ARBITRARY) || !(eps)->arbitrary,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s does not support arbitrary selection of eigenpairs",((PetscObject)(eps))->type_name,(msg)); \
+      if ((mask) & EPS_FEATURE_REGION) { \
+        PetscBool      __istrivial; \
+        PetscCall(RGIsTrivial((eps)->rg,&__istrivial)); \
+        PetscCheck(__istrivial,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s does not support region filtering",((PetscObject)(eps))->type_name,(msg)); \
+      } \
+      PetscCheck(!((mask) & EPS_FEATURE_EXTRACTION) || (eps)->extraction==EPS_RITZ,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s only supports Ritz extraction",((PetscObject)(eps))->type_name,(msg)); \
+      PetscCheck(!((mask) & EPS_FEATURE_CONVERGENCE) || (eps)->converged==EPSConvergedRelative,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s only supports the default convergence test",((PetscObject)(eps))->type_name,(msg)); \
+      PetscCheck(!((mask) & EPS_FEATURE_STOPPING) || (eps)->stopping==EPSStoppingBasic,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s only supports the default stopping test",((PetscObject)(eps))->type_name,(msg)); \
+      PetscCheck(!((mask) & EPS_FEATURE_TWOSIDED) || !(eps)->twosided,PetscObjectComm((PetscObject)(eps)),PETSC_ERR_SUP,"The solver '%s'%s cannot compute left eigenvectors (no two-sided variant)",((PetscObject)(eps))->type_name,(msg)); \
+    } \
+  } while (0)
+#define EPSCheckUnsupported(eps,mask) EPSCheckUnsupportedCondition(eps,mask,PETSC_TRUE,"")
+
+/* Check for ignored features */
+#define EPSCheckIgnoredCondition(eps,mask,condition,msg) \
+  do { \
+    if (condition) { \
+      if (((mask) & EPS_FEATURE_BALANCE) && (eps)->balance!=EPS_BALANCE_NONE) PetscCall(PetscInfo((eps),"The solver '%s'%s ignores the balancing settings\n",((PetscObject)(eps))->type_name,(msg))); \
+      if (((mask) & EPS_FEATURE_ARBITRARY) && (eps)->arbitrary) PetscCall(PetscInfo((eps),"The solver '%s'%s ignores the settings for arbitrary selection of eigenpairs\n",((PetscObject)(eps))->type_name,(msg))); \
+      if ((mask) & EPS_FEATURE_REGION) { \
+        PetscBool __istrivial; \
+        PetscCall(RGIsTrivial((eps)->rg,&__istrivial)); \
+        if (!__istrivial) PetscCall(PetscInfo((eps),"The solver '%s'%s ignores the specified region\n",((PetscObject)(eps))->type_name,(msg))); \
+      } \
+      if (((mask) & EPS_FEATURE_EXTRACTION) && (eps)->extraction!=EPS_RITZ) PetscCall(PetscInfo((eps),"The solver '%s'%s ignores the extraction settings\n",((PetscObject)(eps))->type_name,(msg))); \
+      if (((mask) & EPS_FEATURE_CONVERGENCE) && (eps)->converged!=EPSConvergedRelative) PetscCall(PetscInfo((eps),"The solver '%s'%s ignores the convergence test settings\n",((PetscObject)(eps))->type_name,(msg))); \
+      if (((mask) & EPS_FEATURE_STOPPING) && (eps)->stopping!=EPSStoppingBasic) PetscCall(PetscInfo((eps),"The solver '%s'%s ignores the stopping test settings\n",((PetscObject)(eps))->type_name,(msg))); \
+      if (((mask) & EPS_FEATURE_TWOSIDED) && (eps)->twosided) PetscCall(PetscInfo((eps),"The solver '%s'%s ignores the two-sided flag\n",((PetscObject)(eps))->type_name,(msg))); \
+    } \
+  } while (0)
+#define EPSCheckIgnored(eps,mask) EPSCheckIgnoredCondition(eps,mask,PETSC_TRUE,"")
+
+/*
+  EPS_SetInnerProduct - set B matrix for inner product if appropriate.
+*/
+static inline PetscErrorCode EPS_SetInnerProduct(EPS eps)
+{
+  Mat            B;
+
+  PetscFunctionBegin;
+  if (!eps->V) PetscCall(EPSGetBV(eps,&eps->V));
+  if (eps->ispositive || (eps->isgeneralized && eps->ishermitian)) {
+    PetscCall(STGetBilinearForm(eps->st,&B));
+    PetscCall(BVSetMatrix(eps->V,B,PetscNot(eps->ispositive)));
+    PetscCall(MatDestroy(&B));
+  } else PetscCall(BVSetMatrix(eps->V,NULL,PETSC_FALSE));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+  EPS_Purify - purify the first k vectors in the V basis
+*/
+static inline PetscErrorCode EPS_Purify(EPS eps,PetscInt k)
+{
+  PetscInt       i;
+  Vec            v,z;
+
+  PetscFunctionBegin;
+  PetscCall(BVCreateVec(eps->V,&v));
+  for (i=0;i<k;i++) {
+    PetscCall(BVCopyVec(eps->V,i,v));
+    PetscCall(BVGetColumn(eps->V,i,&z));
+    PetscCall(STApply(eps->st,v,z));
+    PetscCall(BVRestoreColumn(eps->V,i,&z));
+  }
+  PetscCall(VecDestroy(&v));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+  EPS_KSPSetOperators - Sets the KSP matrices, see also ST_KSPSetOperators()
+*/
+static inline PetscErrorCode EPS_KSPSetOperators(KSP ksp,Mat A,Mat B)
+{
+  const char     *prefix;
+
+  PetscFunctionBegin;
+  PetscCall(KSPSetOperators(ksp,A,B));
+  PetscCall(MatGetOptionsPrefix(B,&prefix));
+  if (!prefix) {
+    /* set Mat prefix to be the same as KSP to enable setting command-line options (e.g. MUMPS)
+       only applies if the Mat has no user-defined prefix */
+    PetscCall(KSPGetOptionsPrefix(ksp,&prefix));
+    PetscCall(MatSetOptionsPrefix(B,prefix));
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+  EPS_GetActualConverged - Gets the actual value of nconv; in special cases the
+  number of available eigenvalues is larger than the computed ones
+*/
+static inline PetscErrorCode EPS_GetActualConverged(EPS eps,PetscInt *nconv)
+{
+  PetscFunctionBegin;
+  *nconv = eps->nconv;
+  if (eps->isstructured) {
+    if (eps->problem_type == EPS_BSE && (eps->which == EPS_SMALLEST_MAGNITUDE || eps->which == EPS_LARGEST_MAGNITUDE || eps->which == EPS_TARGET_MAGNITUDE)) *nconv *= 2;
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+  EPS_GetEigenvector - Gets the i-th eigenvector taking into account the case
+  where i exceeds the number of computed vectors (structure-preserving solver).
+  The argument V should be eps->V for right eigenvectors, eps->W for left ones.
+*/
+static inline PetscErrorCode EPS_GetEigenvector(EPS eps,BV V,PetscInt i,Vec Vr,Vec Vi)
+{
+  PetscInt k;
+  Vec      v0,v1,w,w0,w1;
+  Mat      H;
+  IS       is[2];
+
+  PetscFunctionBegin;
+  if (!eps->isstructured) {
+    k = eps->perm[i];
+    PetscCall(BV_GetEigenvector(V,k,eps->eigi[k],Vr,Vi));
+  } else {
+    if (eps->problem_type == EPS_BSE && (eps->which == EPS_SMALLEST_MAGNITUDE || eps->which == EPS_LARGEST_MAGNITUDE || eps->which == EPS_TARGET_MAGNITUDE)) {
+      /* BSE problem, even index is +lambda, odd index is -lambda */
+      k = eps->perm[i/2];
+      if (i%2) {
+        /* eigenvector of -lambda is J*conj(X) where J=[0 I; I 0] and x is eigenvector of lambda */
+        PetscCall(VecDuplicate(Vr?Vr:Vi,&w));
+        PetscCall(STGetMatrix(eps->st,0,&H));
+        PetscCall(MatNestGetISs(H,is,NULL));
+        if (Vr) {
+          PetscCall(BV_GetEigenvector(V,k,eps->eigi[k],w,NULL));
+          PetscCall(VecConjugate(w));
+          PetscCall(VecGetSubVector(w,is[0],&w0));
+          PetscCall(VecGetSubVector(w,is[1],&w1));
+          PetscCall(VecGetSubVector(Vr,is[0],&v0));
+          PetscCall(VecGetSubVector(Vr,is[1],&v1));
+          PetscCall(VecCopy(w1,v0));
+          PetscCall(VecCopy(w0,v1));
+          PetscCall(VecRestoreSubVector(w,is[0],&w0));
+          PetscCall(VecRestoreSubVector(w,is[1],&w1));
+          PetscCall(VecRestoreSubVector(Vr,is[0],&v0));
+          PetscCall(VecRestoreSubVector(Vr,is[1],&v1));
+        }
+#if !defined(PETSC_USE_COMPLEX)
+        if (Vi) {
+          PetscCall(BV_GetEigenvector(V,k,eps->eigi[k],NULL,w));
+          PetscCall(VecScale(w,-1.0));
+          PetscCall(VecGetSubVector(w,is[0],&w0));
+          PetscCall(VecGetSubVector(w,is[1],&w1));
+          PetscCall(VecGetSubVector(Vi,is[0],&v0));
+          PetscCall(VecGetSubVector(Vi,is[1],&v1));
+          PetscCall(VecCopy(w1,v0));
+          PetscCall(VecCopy(w0,v1));
+          PetscCall(VecRestoreSubVector(w,is[0],&w0));
+          PetscCall(VecRestoreSubVector(w,is[1],&w1));
+          PetscCall(VecRestoreSubVector(Vi,is[0],&v0));
+          PetscCall(VecRestoreSubVector(Vi,is[1],&v1));
+        }
+#endif
+        PetscCall(VecDestroy(&w));
+      } else {
+        PetscCall(BV_GetEigenvector(V,k,eps->eigi[k],Vr,Vi));
+      }
+    } else SETERRQ(PetscObjectComm((PetscObject)eps),PETSC_ERR_LIB,"Inconsistent state");
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+SLEPC_INTERN PetscErrorCode EPSSetWhichEigenpairs_Default(EPS);
+SLEPC_INTERN PetscErrorCode EPSSetDimensions_Default(EPS,PetscInt,PetscInt*,PetscInt*);
+SLEPC_INTERN PetscErrorCode EPSBackTransform_Default(EPS);
+SLEPC_INTERN PetscErrorCode EPSComputeVectors(EPS);
+SLEPC_INTERN PetscErrorCode EPSComputeVectors_Hermitian(EPS);
+SLEPC_INTERN PetscErrorCode EPSComputeVectors_Schur(EPS);
+SLEPC_INTERN PetscErrorCode EPSComputeVectors_Indefinite(EPS);
+SLEPC_INTERN PetscErrorCode EPSComputeVectors_Twosided(EPS);
+SLEPC_INTERN PetscErrorCode EPSComputeVectors_Slice(EPS);
+SLEPC_INTERN PetscErrorCode EPSComputeResidualNorm_Private(EPS,PetscBool,PetscScalar,PetscScalar,Vec,Vec,Vec*,PetscReal*);
+SLEPC_INTERN PetscErrorCode EPSComputeRitzVector(EPS,PetscScalar*,PetscScalar*,BV,Vec,Vec);
+SLEPC_INTERN PetscErrorCode EPSGetStartVector(EPS,PetscInt,PetscBool*);
+SLEPC_INTERN PetscErrorCode EPSGetLeftStartVector(EPS,PetscInt,PetscBool*);
+SLEPC_INTERN PetscErrorCode MatEstimateSpectralRange_EPS(Mat,PetscReal*,PetscReal*);
+
+/* Private functions of the solver implementations */
+
+SLEPC_INTERN PetscErrorCode EPSDelayedArnoldi(EPS,PetscScalar*,PetscInt,PetscInt,PetscInt*,PetscReal*,PetscBool*);
+SLEPC_INTERN PetscErrorCode EPSDelayedArnoldi1(EPS,PetscScalar*,PetscInt,PetscInt,PetscInt*,PetscReal*,PetscBool*);
+SLEPC_INTERN PetscErrorCode EPSKrylovConvergence(EPS,PetscBool,PetscInt,PetscInt,PetscReal,PetscReal,PetscReal,PetscInt*);
+SLEPC_INTERN PetscErrorCode EPSPseudoLanczos(EPS,PetscReal*,PetscReal*,PetscReal*,PetscInt,PetscInt*,PetscBool*,PetscBool*,PetscReal*,Vec);
+SLEPC_INTERN PetscErrorCode EPSBuildBalance_Krylov(EPS);
+SLEPC_INTERN PetscErrorCode EPSSetDefaultST(EPS);
+SLEPC_INTERN PetscErrorCode EPSSetDefaultST_Precond(EPS);
+SLEPC_INTERN PetscErrorCode EPSSetDefaultST_GMRES(EPS);
+SLEPC_INTERN PetscErrorCode EPSSetDefaultST_NoFactor(EPS);
+SLEPC_INTERN PetscErrorCode EPSSetUpSort_Basic(EPS);
+SLEPC_INTERN PetscErrorCode EPSSetUpSort_Default(EPS);

--- a/3rd/slepc/linux/include/slepc/private/fnimpl.h
+++ b/3rd/slepc/linux/include/slepc/private/fnimpl.h
@@ -1,0 +1,110 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepcfn.h>
+#include <slepc/private/slepcimpl.h>
+
+/* SUBMANSEC = FN */
+
+SLEPC_EXTERN PetscBool FNRegisterAllCalled;
+SLEPC_EXTERN PetscErrorCode FNRegisterAll(void);
+SLEPC_EXTERN PetscLogEvent FN_Evaluate;
+
+typedef struct _FNOps *FNOps;
+
+struct _FNOps {
+  PetscErrorCode (*evaluatefunction)(FN,PetscScalar,PetscScalar*);
+  PetscErrorCode (*evaluatederivative)(FN,PetscScalar,PetscScalar*);
+  PetscErrorCode (*evaluatefunctionmat[FN_MAX_SOLVE])(FN,Mat,Mat);
+  PetscErrorCode (*evaluatefunctionmatcuda[FN_MAX_SOLVE])(FN,Mat,Mat);
+  PetscErrorCode (*evaluatefunctionmatvec[FN_MAX_SOLVE])(FN,Mat,Vec);
+  PetscErrorCode (*evaluatefunctionmatveccuda[FN_MAX_SOLVE])(FN,Mat,Vec);
+  PetscErrorCode (*setfromoptions)(FN,PetscOptionItems*);
+  PetscErrorCode (*view)(FN,PetscViewer);
+  PetscErrorCode (*duplicate)(FN,MPI_Comm,FN*);
+  PetscErrorCode (*destroy)(FN);
+};
+
+#define FN_MAX_W 6
+
+struct _p_FN {
+  PETSCHEADER(struct _FNOps);
+  /*------------------------- User parameters --------------------------*/
+  PetscScalar    alpha;          /* inner scaling (argument) */
+  PetscScalar    beta;           /* outer scaling (result) */
+  PetscInt       method;         /* the method to compute matrix functions */
+  FNParallelType pmode;          /* parallel mode (redundant or synchronized) */
+
+  /*---------------------- Cached data and workspace -------------------*/
+  Mat            W[FN_MAX_W];    /* workspace matrices */
+  PetscInt       nw;             /* number of allocated W matrices */
+  PetscInt       cw;             /* current W matrix */
+  void           *data;
+};
+
+/*
+  FN_AllocateWorkMat - Allocate a work Mat of the same dimension of A and copy
+  its contents. The work matrix is returned in M and should be freed with
+  FN_FreeWorkMat().
+*/
+static inline PetscErrorCode FN_AllocateWorkMat(FN fn,Mat A,Mat *M)
+{
+  PetscInt       n,na;
+  PetscBool      create=PETSC_FALSE;
+
+  PetscFunctionBegin;
+  *M = NULL;
+  PetscCheck(fn->cw<FN_MAX_W,PETSC_COMM_SELF,PETSC_ERR_SUP,"Too many requested work matrices %" PetscInt_FMT,fn->cw);
+  if (fn->nw<=fn->cw) {
+    create=PETSC_TRUE;
+    fn->nw++;
+  } else {
+    PetscCall(MatGetSize(fn->W[fn->cw],&n,NULL));
+    PetscCall(MatGetSize(A,&na,NULL));
+    if (n!=na) {
+      PetscCall(MatDestroy(&fn->W[fn->cw]));
+      create=PETSC_TRUE;
+    }
+  }
+  if (create) PetscCall(MatDuplicate(A,MAT_COPY_VALUES,&fn->W[fn->cw]));
+  else PetscCall(MatCopy(A,fn->W[fn->cw],SAME_NONZERO_PATTERN));
+  *M = fn->W[fn->cw];
+  fn->cw++;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+  FN_FreeWorkMat - Release a work matrix created with FN_AllocateWorkMat().
+*/
+static inline PetscErrorCode FN_FreeWorkMat(FN fn,Mat *M)
+{
+  PetscFunctionBegin;
+  PetscCheck(fn->cw,PETSC_COMM_SELF,PETSC_ERR_ARG_WRONG,"There are no work matrices");
+  fn->cw--;
+  PetscCheck(fn->W[fn->cw]==*M,PETSC_COMM_SELF,PETSC_ERR_ARG_WRONG,"Work matrices must be freed in the reverse order of their creation");
+  *M = NULL;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+SLEPC_INTERN PetscErrorCode FNSqrtmSchur(FN,PetscBLASInt,PetscScalar*,PetscBLASInt,PetscBool);
+SLEPC_INTERN PetscErrorCode FNSqrtmDenmanBeavers(FN,PetscBLASInt,PetscScalar*,PetscBLASInt,PetscBool);
+SLEPC_INTERN PetscErrorCode FNSqrtmNewtonSchulz(FN,PetscBLASInt,PetscScalar*,PetscBLASInt,PetscBool);
+SLEPC_INTERN PetscErrorCode FNSqrtmSadeghi(FN,PetscBLASInt,PetscScalar*,PetscBLASInt);
+SLEPC_INTERN PetscErrorCode SlepcNormAm(PetscBLASInt,PetscScalar*,PetscInt,PetscScalar*,PetscRandom,PetscReal*);
+SLEPC_INTERN PetscErrorCode FNEvaluateFunctionMat_Private(FN,Mat,Mat,PetscBool);
+SLEPC_INTERN PetscErrorCode FNEvaluateFunctionMatVec_Private(FN,Mat,Vec,PetscBool);
+SLEPC_INTERN PetscErrorCode FNEvaluateFunctionMat_Exp_Higham(FN,Mat,Mat); /* used in FNPHI */
+#if defined(PETSC_HAVE_CUDA)
+SLEPC_INTERN PetscErrorCode FNSqrtmDenmanBeavers_CUDAm(FN,PetscBLASInt,PetscScalar*,PetscBLASInt,PetscBool);
+SLEPC_INTERN PetscErrorCode FNSqrtmNewtonSchulz_CUDA(FN,PetscBLASInt,PetscScalar*,PetscBLASInt,PetscBool);
+SLEPC_INTERN PetscErrorCode FNSqrtmSadeghi_CUDAm(FN,PetscBLASInt,PetscScalar*,PetscBLASInt);
+#endif

--- a/3rd/slepc/linux/include/slepc/private/lmeimpl.h
+++ b/3rd/slepc/linux/include/slepc/private/lmeimpl.h
@@ -1,0 +1,109 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepclme.h>
+#include <slepc/private/slepcimpl.h>
+
+/* SUBMANSEC = LME */
+
+SLEPC_EXTERN PetscBool LMERegisterAllCalled;
+SLEPC_EXTERN PetscBool LMEMonitorRegisterAllCalled;
+SLEPC_EXTERN PetscErrorCode LMERegisterAll(void);
+SLEPC_EXTERN PetscErrorCode LMEMonitorRegisterAll(void);
+SLEPC_EXTERN PetscLogEvent LME_SetUp,LME_Solve,LME_ComputeError;
+
+typedef struct _LMEOps *LMEOps;
+
+struct _LMEOps {
+  PetscErrorCode (*solve[sizeof(LMEProblemType)])(LME);
+  PetscErrorCode (*setup)(LME);
+  PetscErrorCode (*setfromoptions)(LME,PetscOptionItems*);
+  PetscErrorCode (*publishoptions)(LME);
+  PetscErrorCode (*destroy)(LME);
+  PetscErrorCode (*reset)(LME);
+  PetscErrorCode (*view)(LME,PetscViewer);
+};
+
+/*
+     Maximum number of monitors you can run with a single LME
+*/
+#define MAXLMEMONITORS 5
+
+/*
+   Defines the LME data structure.
+*/
+struct _p_LME {
+  PETSCHEADER(struct _LMEOps);
+  /*------------------------- User parameters ---------------------------*/
+  Mat            A,B,D,E;        /* the coefficient matrices */
+  Mat            C;              /* the right-hand side */
+  Mat            X;              /* the solution */
+  LMEProblemType problem_type;   /* which kind of equation to be solved */
+  PetscInt       max_it;         /* maximum number of iterations */
+  PetscInt       ncv;            /* number of basis vectors */
+  PetscReal      tol;            /* tolerance */
+  PetscBool      errorifnotconverged;    /* error out if LMESolve() does not converge */
+
+  /*-------------- User-provided functions and contexts -----------------*/
+  PetscErrorCode (*monitor[MAXLMEMONITORS])(LME,PetscInt,PetscReal,void*);
+  PetscErrorCode (*monitordestroy[MAXLMEMONITORS])(void**);
+  void           *monitorcontext[MAXLMEMONITORS];
+  PetscInt       numbermonitors;
+
+  /*----------------- Child objects and working data -------------------*/
+  BV             V;              /* set of basis vectors */
+  PetscInt       nwork;          /* number of work vectors */
+  Vec            *work;          /* work vectors */
+  void           *data;          /* placeholder for solver-specific stuff */
+
+  /* ----------------------- Status variables -------------------------- */
+  PetscInt       its;            /* number of iterations so far computed */
+  PetscReal      errest;         /* error estimate */
+  PetscInt       setupcalled;
+  LMEConvergedReason reason;
+};
+
+SLEPC_INTERN PetscErrorCode LMEDenseRankSVD(LME,PetscInt,PetscScalar*,PetscInt,PetscScalar*,PetscInt,PetscInt*);
+
+/*
+    Macros to test valid LME arguments
+*/
+#if !defined(PETSC_USE_DEBUG)
+
+#define LMECheckCoeff(h,A,mat,eq) do {(void)(h);} while (0)
+
+#else
+
+#define LMECheckCoeff(h,A,mat,eq) \
+  do { \
+    PetscCheck(A,PetscObjectComm((PetscObject)(h)),PETSC_ERR_ARG_WRONGSTATE,"%s matrix equation requires coefficient matrix %s",eq,mat); \
+  } while (0)
+
+#endif
+
+/* functions interfaced from Fortran library SLICOT */
+#if defined(SLEPC_HAVE_SLICOT)
+
+#if defined(SLEPC_SLICOT_HAVE_UNDERSCORE)
+#define SLEPC_SLICOT(lcase,ucase) lcase##_
+#elif defined(SLEPC_SLICOT_HAVE_CAPS)
+#define SLEPC_SLICOT(lcase,ucase) ucase
+#else
+#define SLEPC_SLICOT(lcase,ucase) lcase
+#endif
+
+#define SLICOTsb03od_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q) SLEPC_SLICOT(sb03od,SB03OD) ((a),(b),(c),(d),(e),(f),(g),(h),(i),(j),(k),(l),(m),(n),(o),(p),(q),1,1,1)
+SLEPC_EXTERN void SLEPC_SLICOT(sb03od,SB03OD)(const char*,const char*,const char*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscReal*,PetscScalar*,PetscScalar*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt,PetscBLASInt,PetscBLASInt);
+#define SLICOTsb03md_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t) SLEPC_SLICOT(sb03md,SB03MD) ((a),(b),(c),(d),(e),(f),(g),(h),(i),(j),(k),(l),(m),(n),(o),(p),(q),(r),(s),(t),1,1,1,1)
+SLEPC_EXTERN void SLEPC_SLICOT(sb03md,SB03MD)(const char*,const char*,const char*,const char*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscReal*,PetscReal*,PetscReal*,PetscScalar*,PetscScalar*,PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt,PetscBLASInt,PetscBLASInt,PetscBLASInt);
+
+#endif

--- a/3rd/slepc/linux/include/slepc/private/mfnimpl.h
+++ b/3rd/slepc/linux/include/slepc/private/mfnimpl.h
@@ -1,0 +1,117 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepcmfn.h>
+#include <slepc/private/slepcimpl.h>
+
+/* SUBMANSEC = MFN */
+
+SLEPC_EXTERN PetscBool MFNRegisterAllCalled;
+SLEPC_EXTERN PetscBool MFNMonitorRegisterAllCalled;
+SLEPC_EXTERN PetscErrorCode MFNRegisterAll(void);
+SLEPC_EXTERN PetscErrorCode MFNMonitorRegisterAll(void);
+SLEPC_EXTERN PetscLogEvent MFN_SetUp,MFN_Solve;
+
+typedef struct _MFNOps *MFNOps;
+
+struct _MFNOps {
+  PetscErrorCode (*solve)(MFN,Vec,Vec);
+  PetscErrorCode (*setup)(MFN);
+  PetscErrorCode (*setfromoptions)(MFN,PetscOptionItems*);
+  PetscErrorCode (*publishoptions)(MFN);
+  PetscErrorCode (*destroy)(MFN);
+  PetscErrorCode (*reset)(MFN);
+  PetscErrorCode (*view)(MFN,PetscViewer);
+};
+
+/*
+     Maximum number of monitors you can run with a single MFN
+*/
+#define MAXMFNMONITORS 5
+
+/*
+   Defines the MFN data structure.
+*/
+struct _p_MFN {
+  PETSCHEADER(struct _MFNOps);
+  /*------------------------- User parameters ---------------------------*/
+  Mat            A;                /* the problem matrix */
+  FN             fn;               /* which function to compute */
+  PetscInt       max_it;           /* maximum number of iterations */
+  PetscInt       ncv;              /* number of basis vectors */
+  PetscReal      tol;              /* tolerance */
+  PetscBool      errorifnotconverged;    /* error out if MFNSolve() does not converge */
+
+  /*-------------- User-provided functions and contexts -----------------*/
+  PetscErrorCode (*monitor[MAXMFNMONITORS])(MFN,PetscInt,PetscReal,void*);
+  PetscErrorCode (*monitordestroy[MAXMFNMONITORS])(void**);
+  void           *monitorcontext[MAXMFNMONITORS];
+  PetscInt       numbermonitors;
+
+  /*----------------- Child objects and working data -------------------*/
+  BV             V;                /* set of basis vectors */
+  Mat            AT;               /* the transpose of A, used in MFNSolveTranspose */
+  PetscInt       nwork;            /* number of work vectors */
+  Vec            *work;            /* work vectors */
+  void           *data;            /* placeholder for solver-specific stuff */
+
+  /* ----------------------- Status variables -------------------------- */
+  PetscInt       its;              /* number of iterations so far computed */
+  PetscInt       nv;               /* size of current Schur decomposition */
+  PetscReal      errest;           /* error estimate */
+  PetscReal      bnorm;            /* computed norm of right-hand side in current solve */
+  PetscBool      transpose_solve;  /* solve transpose system instead */
+  PetscInt       setupcalled;
+  MFNConvergedReason reason;
+};
+
+/*
+   MFN_CreateDenseMat - Creates a dense Mat of size k unless it already has that size
+*/
+static inline PetscErrorCode MFN_CreateDenseMat(PetscInt k,Mat *A)
+{
+  PetscBool      create=PETSC_FALSE;
+  PetscInt       m,n;
+
+  PetscFunctionBegin;
+  if (!*A) create=PETSC_TRUE;
+  else {
+    PetscCall(MatGetSize(*A,&m,&n));
+    if (m!=k || n!=k) {
+      PetscCall(MatDestroy(A));
+      create=PETSC_TRUE;
+    }
+  }
+  if (create) PetscCall(MatCreateSeqDense(PETSC_COMM_SELF,k,k,NULL,A));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   MFN_CreateVec - Creates a Vec of size k unless it already has that size
+*/
+static inline PetscErrorCode MFN_CreateVec(PetscInt k,Vec *v)
+{
+  PetscBool      create=PETSC_FALSE;
+  PetscInt       n;
+
+  PetscFunctionBegin;
+  if (!*v) create=PETSC_TRUE;
+  else {
+    PetscCall(VecGetSize(*v,&n));
+    if (n!=k) {
+      PetscCall(VecDestroy(v));
+      create=PETSC_TRUE;
+    }
+  }
+  if (create) PetscCall(VecCreateSeq(PETSC_COMM_SELF,k,v));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}

--- a/3rd/slepc/linux/include/slepc/private/nepimpl.h
+++ b/3rd/slepc/linux/include/slepc/private/nepimpl.h
@@ -1,0 +1,240 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepcnep.h>
+#include <slepc/private/slepcimpl.h>
+
+/* SUBMANSEC = NEP */
+
+SLEPC_EXTERN PetscBool NEPRegisterAllCalled;
+SLEPC_EXTERN PetscBool NEPMonitorRegisterAllCalled;
+SLEPC_EXTERN PetscErrorCode NEPRegisterAll(void);
+SLEPC_EXTERN PetscErrorCode NEPMonitorRegisterAll(void);
+SLEPC_EXTERN PetscLogEvent NEP_SetUp,NEP_Solve,NEP_Refine,NEP_FunctionEval,NEP_JacobianEval,NEP_Resolvent,NEP_CISS_SVD;
+
+typedef struct _NEPOps *NEPOps;
+
+struct _NEPOps {
+  PetscErrorCode (*solve)(NEP);
+  PetscErrorCode (*setup)(NEP);
+  PetscErrorCode (*setfromoptions)(NEP,PetscOptionItems*);
+  PetscErrorCode (*publishoptions)(NEP);
+  PetscErrorCode (*destroy)(NEP);
+  PetscErrorCode (*reset)(NEP);
+  PetscErrorCode (*view)(NEP,PetscViewer);
+  PetscErrorCode (*computevectors)(NEP);
+  PetscErrorCode (*setdstype)(NEP);
+};
+
+/*
+     Maximum number of monitors you can run with a single NEP
+*/
+#define MAXNEPMONITORS 5
+
+typedef enum { NEP_STATE_INITIAL,
+               NEP_STATE_SETUP,
+               NEP_STATE_SOLVED,
+               NEP_STATE_EIGENVECTORS } NEPStateType;
+
+/*
+     How the problem function T(lambda) has been defined by the user
+     - Callback: one callback to build the function matrix, another one for the Jacobian
+     - Split: in split form sum_j(A_j*f_j(lambda))
+*/
+typedef enum { NEP_USER_INTERFACE_CALLBACK=1,
+               NEP_USER_INTERFACE_SPLIT } NEPUserInterface;
+
+/*
+   To check for unsupported features at NEPSetUp_XXX()
+*/
+typedef enum { NEP_FEATURE_CALLBACK=1,      /* callback user interface */
+               NEP_FEATURE_REGION=4,        /* nontrivial region for filtering */
+               NEP_FEATURE_CONVERGENCE=16,  /* convergence test selected by user */
+               NEP_FEATURE_STOPPING=32,     /* stopping test */
+               NEP_FEATURE_TWOSIDED=64      /* two-sided variant */
+             } NEPFeatureType;
+
+/*
+   Defines the NEP data structure.
+*/
+struct _p_NEP {
+  PETSCHEADER(struct _NEPOps);
+  /*------------------------- User parameters ---------------------------*/
+  PetscInt       max_it;           /* maximum number of iterations */
+  PetscInt       nev;              /* number of eigenvalues to compute */
+  PetscInt       ncv;              /* number of basis vectors */
+  PetscInt       mpd;              /* maximum dimension of projected problem */
+  PetscInt       nini;             /* number of initial vectors (negative means not copied yet) */
+  PetscScalar    target;           /* target value */
+  PetscReal      tol;              /* tolerance */
+  NEPConv        conv;             /* convergence test */
+  NEPStop        stop;             /* stopping test */
+  NEPWhich       which;            /* which part of the spectrum to be sought */
+  NEPProblemType problem_type;     /* which kind of problem to be solved */
+  NEPRefine      refine;           /* type of refinement to be applied after solve */
+  PetscInt       npart;            /* number of partitions of the communicator */
+  PetscReal      rtol;             /* tolerance for refinement */
+  PetscInt       rits;             /* number of iterations of the refinement method */
+  NEPRefineScheme scheme;          /* scheme for solving linear systems within refinement */
+  PetscBool      trackall;         /* whether all the residuals must be computed */
+  PetscBool      twosided;         /* whether to compute left eigenvectors (two-sided solver) */
+
+  /*-------------- User-provided functions and contexts -----------------*/
+  NEPFunctionFn        *computefunction;
+  NEPJacobianFn        *computejacobian;
+  void                 *functionctx;
+  void                 *jacobianctx;
+  NEPConvergenceTestFn *converged;
+  NEPConvergenceTestFn *convergeduser;
+  PetscErrorCode       (*convergeddestroy)(void*);
+  NEPStoppingTestFn    *stopping;
+  NEPStoppingTestFn    *stoppinguser;
+  PetscErrorCode      (*stoppingdestroy)(void*);
+  void           *convergedctx;
+  void           *stoppingctx;
+  PetscErrorCode (*monitor[MAXNEPMONITORS])(NEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,void*);
+  PetscErrorCode (*monitordestroy[MAXNEPMONITORS])(void**);
+  void           *monitorcontext[MAXNEPMONITORS];
+  PetscInt       numbermonitors;
+
+  /*----------------- Child objects and working data -------------------*/
+  DS             ds;               /* direct solver object */
+  BV             V;                /* set of basis vectors and computed eigenvectors */
+  BV             W;                /* left basis vectors (if left eigenvectors requested) */
+  RG             rg;               /* optional region for filtering */
+  SlepcSC        sc;               /* sorting criterion data */
+  Mat            function;         /* function matrix */
+  Mat            function_pre;     /* function matrix (preconditioner) */
+  Mat            jacobian;         /* Jacobian matrix */
+  Mat            *A;               /* matrix coefficients of split form */
+  FN             *f;               /* matrix functions of split form */
+  PetscInt       nt;               /* number of terms in split form */
+  MatStructure   mstr;             /* pattern of split matrices */
+  Mat            *P;               /* matrix coefficients of split form (preconditioner) */
+  MatStructure   mstrp;            /* pattern of split matrices (preconditioner) */
+  Vec            *IS;              /* references to user-provided initial space */
+  PetscScalar    *eigr,*eigi;      /* real and imaginary parts of eigenvalues */
+  PetscReal      *errest;          /* error estimates */
+  PetscInt       *perm;            /* permutation for eigenvalue ordering */
+  PetscInt       nwork;            /* number of work vectors */
+  Vec            *work;            /* work vectors */
+  KSP            refineksp;        /* ksp used in refinement */
+  PetscSubcomm   refinesubc;       /* context for sub-communicators */
+  void           *data;            /* placeholder for solver-specific stuff */
+
+  /* ----------------------- Status variables --------------------------*/
+  NEPStateType   state;            /* initial -> setup -> solved -> eigenvectors */
+  PetscInt       nconv;            /* number of converged eigenvalues */
+  PetscInt       its;              /* number of iterations so far computed */
+  PetscInt       n,nloc;           /* problem dimensions (global, local) */
+  PetscReal      *nrma;            /* computed matrix norms */
+  NEPUserInterface fui;            /* how the user has defined the nonlinear operator */
+  PetscBool      useds;            /* whether the solver uses the DS object or not */
+  Mat            resolvent;        /* shell matrix to be used in NEPApplyResolvent */
+  NEPConvergedReason reason;
+};
+
+/*
+    Macros to test valid NEP arguments
+*/
+#if !defined(PETSC_USE_DEBUG)
+
+#define NEPCheckProblem(h,arg) do {(void)(h);} while (0)
+#define NEPCheckCallback(h,arg) do {(void)(h);} while (0)
+#define NEPCheckSplit(h,arg) do {(void)(h);} while (0)
+#define NEPCheckDerivatives(h,arg) do {(void)(h);} while (0)
+#define NEPCheckSolved(h,arg) do {(void)(h);} while (0)
+
+#else
+
+#define NEPCheckProblem(h,arg) \
+  do { \
+    PetscCheck(((h)->fui),PetscObjectComm((PetscObject)(h)),PETSC_ERR_ARG_WRONGSTATE,"The nonlinear eigenproblem has not been specified yet. Parameter #%d",arg); \
+  } while (0)
+
+#define NEPCheckCallback(h,arg) \
+  do { \
+    PetscCheck((h)->fui==NEP_USER_INTERFACE_CALLBACK,PetscObjectComm((PetscObject)(h)),PETSC_ERR_ARG_WRONGSTATE,"This operation requires the nonlinear eigenproblem specified with callbacks. Parameter #%d",arg); \
+  } while (0)
+
+#define NEPCheckSplit(h,arg) \
+  do { \
+    PetscCheck((h)->fui==NEP_USER_INTERFACE_SPLIT,PetscObjectComm((PetscObject)(h)),PETSC_ERR_ARG_WRONGSTATE,"This operation requires the nonlinear eigenproblem in split form. Parameter #%d",arg); \
+  } while (0)
+
+#define NEPCheckSolved(h,arg) \
+  do { \
+    PetscCheck((h)->state>=NEP_STATE_SOLVED,PetscObjectComm((PetscObject)(h)),PETSC_ERR_ARG_WRONGSTATE,"Must call NEPSolve() first: Parameter #%d",arg); \
+  } while (0)
+
+#endif
+
+/* Check for unsupported features */
+#define NEPCheckUnsupportedCondition(nep,mask,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscCheck(!((mask) & NEP_FEATURE_CALLBACK) || (nep)->fui!=NEP_USER_INTERFACE_CALLBACK,PetscObjectComm((PetscObject)(nep)),PETSC_ERR_SUP,"The solver '%s'%s cannot be used with callback functions (use the split operator)",((PetscObject)(nep))->type_name,(msg)); \
+      if ((mask) & NEP_FEATURE_REGION) { \
+        PetscBool      __istrivial; \
+        PetscCall(RGIsTrivial((nep)->rg,&__istrivial)); \
+        PetscCheck(__istrivial,PetscObjectComm((PetscObject)(nep)),PETSC_ERR_SUP,"The solver '%s'%s does not support region filtering",((PetscObject)(nep))->type_name,(msg)); \
+      } \
+      PetscCheck(!((mask) & NEP_FEATURE_CONVERGENCE) || (nep)->converged==NEPConvergedRelative,PetscObjectComm((PetscObject)(nep)),PETSC_ERR_SUP,"The solver '%s'%s only supports the default convergence test",((PetscObject)(nep))->type_name,(msg)); \
+      PetscCheck(!((mask) & NEP_FEATURE_STOPPING) || (nep)->stopping==NEPStoppingBasic,PetscObjectComm((PetscObject)(nep)),PETSC_ERR_SUP,"The solver '%s'%s only supports the default stopping test",((PetscObject)(nep))->type_name,(msg)); \
+      PetscCheck(!((mask) & NEP_FEATURE_TWOSIDED) || !(nep)->twosided,PetscObjectComm((PetscObject)(nep)),PETSC_ERR_SUP,"The solver '%s'%s cannot compute left eigenvectors (no two-sided variant)",((PetscObject)(nep))->type_name,(msg)); \
+    } \
+  } while (0)
+#define NEPCheckUnsupported(nep,mask) NEPCheckUnsupportedCondition(nep,mask,PETSC_TRUE,"")
+
+/* Check for ignored features */
+#define NEPCheckIgnoredCondition(nep,mask,condition,msg) \
+  do { \
+    if (condition) { \
+      if (((mask) & NEP_FEATURE_CALLBACK) && (nep)->fui==NEP_USER_INTERFACE_CALLBACK) PetscCall(PetscInfo((nep),"The solver '%s'%s ignores the user interface settings\n",((PetscObject)(nep))->type_name,(msg))); \
+      if ((mask) & NEP_FEATURE_REGION) { \
+        PetscBool __istrivial; \
+        PetscCall(RGIsTrivial((nep)->rg,&__istrivial)); \
+        if (!__istrivial) PetscCall(PetscInfo((nep),"The solver '%s'%s ignores the specified region\n",((PetscObject)(nep))->type_name,(msg))); \
+      } \
+      if (((mask) & NEP_FEATURE_CONVERGENCE) && (nep)->converged!=NEPConvergedRelative) PetscCall(PetscInfo((nep),"The solver '%s'%s ignores the convergence test settings\n",((PetscObject)(nep))->type_name,(msg))); \
+      if (((mask) & NEP_FEATURE_STOPPING) && (nep)->stopping!=NEPStoppingBasic) PetscCall(PetscInfo((nep),"The solver '%s'%s ignores the stopping test settings\n",((PetscObject)(nep))->type_name,(msg))); \
+      if (((mask) & NEP_FEATURE_TWOSIDED) && (nep)->twosided) PetscCall(PetscInfo((nep),"The solver '%s'%s ignores the two-sided flag\n",((PetscObject)(nep))->type_name,(msg))); \
+    } \
+  } while (0)
+#define NEPCheckIgnored(nep,mask) NEPCheckIgnoredCondition(nep,mask,PETSC_TRUE,"")
+
+/*
+  NEP_KSPSetOperators - Sets the KSP matrices
+*/
+static inline PetscErrorCode NEP_KSPSetOperators(KSP ksp,Mat A,Mat B)
+{
+  const char     *prefix;
+
+  PetscFunctionBegin;
+  PetscCall(KSPSetOperators(ksp,A,B));
+  PetscCall(MatGetOptionsPrefix(B,&prefix));
+  if (!prefix) {
+    /* set Mat prefix to be the same as KSP to enable setting command-line options (e.g. MUMPS)
+       only applies if the Mat has no user-defined prefix */
+    PetscCall(KSPGetOptionsPrefix(ksp,&prefix));
+    PetscCall(MatSetOptionsPrefix(B,prefix));
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+SLEPC_INTERN PetscErrorCode NEPSetDimensions_Default(NEP,PetscInt,PetscInt*,PetscInt*);
+SLEPC_INTERN PetscErrorCode NEPComputeVectors(NEP);
+SLEPC_INTERN PetscErrorCode NEPReset_Problem(NEP);
+SLEPC_INTERN PetscErrorCode NEPGetDefaultShift(NEP,PetscScalar*);
+SLEPC_INTERN PetscErrorCode NEPComputeVectors_Schur(NEP);
+SLEPC_INTERN PetscErrorCode NEPComputeResidualNorm_Private(NEP,PetscBool,PetscScalar,Vec,Vec*,PetscReal*);
+SLEPC_INTERN PetscErrorCode NEPNewtonRefinementSimple(NEP,PetscInt*,PetscReal,PetscInt);

--- a/3rd/slepc/linux/include/slepc/private/pepimpl.h
+++ b/3rd/slepc/linux/include/slepc/private/pepimpl.h
@@ -1,0 +1,272 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepcpep.h>
+#include <slepc/private/slepcimpl.h>
+
+/* SUBMANSEC = PEP */
+
+SLEPC_EXTERN PetscBool PEPRegisterAllCalled;
+SLEPC_EXTERN PetscBool PEPMonitorRegisterAllCalled;
+SLEPC_EXTERN PetscErrorCode PEPRegisterAll(void);
+SLEPC_EXTERN PetscErrorCode PEPMonitorRegisterAll(void);
+SLEPC_EXTERN PetscLogEvent PEP_SetUp,PEP_Solve,PEP_Refine,PEP_CISS_SVD;
+
+typedef struct _PEPOps *PEPOps;
+
+struct _PEPOps {
+  PetscErrorCode (*solve)(PEP);
+  PetscErrorCode (*setup)(PEP);
+  PetscErrorCode (*setfromoptions)(PEP,PetscOptionItems*);
+  PetscErrorCode (*publishoptions)(PEP);
+  PetscErrorCode (*destroy)(PEP);
+  PetscErrorCode (*reset)(PEP);
+  PetscErrorCode (*view)(PEP,PetscViewer);
+  PetscErrorCode (*backtransform)(PEP);
+  PetscErrorCode (*computevectors)(PEP);
+  PetscErrorCode (*extractvectors)(PEP);
+  PetscErrorCode (*setdefaultst)(PEP);
+  PetscErrorCode (*setdstype)(PEP);
+};
+
+/*
+     Maximum number of monitors you can run with a single PEP
+*/
+#define MAXPEPMONITORS 5
+
+typedef enum { PEP_STATE_INITIAL,
+               PEP_STATE_SETUP,
+               PEP_STATE_SOLVED,
+               PEP_STATE_EIGENVECTORS } PEPStateType;
+
+/*
+   To check for unsupported features at PEPSetUp_XXX()
+*/
+typedef enum { PEP_FEATURE_NONMONOMIAL=1,   /* non-monomial bases */
+               PEP_FEATURE_REGION=4,        /* nontrivial region for filtering */
+               PEP_FEATURE_EXTRACT=8,       /* eigenvector extraction */
+               PEP_FEATURE_CONVERGENCE=16,  /* convergence test selected by user */
+               PEP_FEATURE_STOPPING=32,     /* stopping test */
+               PEP_FEATURE_SCALE=64         /* scaling */
+             } PEPFeatureType;
+
+/*
+   Defines the PEP data structure.
+*/
+struct _p_PEP {
+  PETSCHEADER(struct _PEPOps);
+  /*------------------------- User parameters ---------------------------*/
+  PetscInt       max_it;           /* maximum number of iterations */
+  PetscInt       nev;              /* number of eigenvalues to compute */
+  PetscInt       ncv;              /* number of basis vectors */
+  PetscInt       mpd;              /* maximum dimension of projected problem */
+  PetscInt       nini;             /* number of initial vectors (negative means not copied yet) */
+  PetscScalar    target;           /* target value */
+  PetscReal      tol;              /* tolerance */
+  PEPConv        conv;             /* convergence test */
+  PEPStop        stop;             /* stopping test */
+  PEPWhich       which;            /* which part of the spectrum to be sought */
+  PetscReal      inta,intb;        /* interval [a,b] for spectrum slicing */
+  PEPBasis       basis;            /* polynomial basis used to represent the problem */
+  PEPProblemType problem_type;     /* which kind of problem to be solved */
+  PEPScale       scale;            /* scaling strategy to be used */
+  PetscReal      sfactor,dsfactor; /* scaling factors */
+  PetscInt       sits;             /* number of iterations of the scaling method */
+  PetscReal      slambda;          /* norm eigenvalue approximation for scaling */
+  PEPRefine      refine;           /* type of refinement to be applied after solve */
+  PetscInt       npart;            /* number of partitions of the communicator */
+  PetscReal      rtol;             /* tolerance for refinement */
+  PetscInt       rits;             /* number of iterations of the refinement method */
+  PEPRefineScheme scheme;          /* scheme for solving linear systems within refinement */
+  PEPExtract     extract;          /* type of extraction used */
+  PetscBool      trackall;         /* whether all the residuals must be computed */
+
+  /*-------------- User-provided functions and contexts -----------------*/
+  PEPConvergenceTestFn *converged;
+  PEPConvergenceTestFn *convergeduser;
+  PetscErrorCode       (*convergeddestroy)(void*);
+  PEPStoppingTestFn    *stopping;
+  PEPStoppingTestFn    *stoppinguser;
+  PetscErrorCode       (*stoppingdestroy)(void*);
+  void           *convergedctx;
+  void           *stoppingctx;
+  PetscErrorCode (*monitor[MAXPEPMONITORS])(PEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,void*);
+  PetscErrorCode (*monitordestroy[MAXPEPMONITORS])(void**);
+  void           *monitorcontext[MAXPEPMONITORS];
+  PetscInt        numbermonitors;
+
+  /*----------------- Child objects and working data -------------------*/
+  ST             st;               /* spectral transformation object */
+  DS             ds;               /* direct solver object */
+  BV             V;                /* set of basis vectors and computed eigenvectors */
+  RG             rg;               /* optional region for filtering */
+  SlepcSC        sc;               /* sorting criterion data */
+  Mat            *A;               /* coefficient matrices of the polynomial */
+  PetscInt       nmat;             /* number of matrices */
+  Vec            Dl,Dr;            /* diagonal matrices for balancing */
+  Vec            *IS;              /* references to user-provided initial space */
+  PetscScalar    *eigr,*eigi;      /* real and imaginary parts of eigenvalues */
+  PetscReal      *errest;          /* error estimates */
+  PetscInt       *perm;            /* permutation for eigenvalue ordering */
+  PetscReal      *pbc;             /* coefficients defining the polynomial basis */
+  PetscScalar    *solvematcoeffs;  /* coefficients to compute the matrix to be inverted */
+  PetscInt       nwork;            /* number of work vectors */
+  Vec            *work;            /* work vectors */
+  KSP            refineksp;        /* ksp used in refinement */
+  PetscSubcomm   refinesubc;       /* context for sub-communicators */
+  void           *data;            /* placeholder for solver-specific stuff */
+
+  /* ----------------------- Status variables --------------------------*/
+  PEPStateType   state;            /* initial -> setup -> solved -> eigenvectors */
+  PetscInt       nconv;            /* number of converged eigenvalues */
+  PetscInt       its;              /* number of iterations so far computed */
+  PetscInt       n,nloc;           /* problem dimensions (global, local) */
+  PetscReal      *nrma;            /* computed matrix norms */
+  PetscReal      nrml[2];          /* computed matrix norms for the linearization */
+  PetscBool      sfactor_set;      /* flag to indicate the user gave sfactor */
+  PetscBool      lineariz;         /* current solver is based on linearization */
+  PEPConvergedReason reason;
+};
+
+/*
+    Macros to test valid PEP arguments
+*/
+#if !defined(PETSC_USE_DEBUG)
+
+#define PEPCheckSolved(h,arg) do {(void)(h);} while (0)
+
+#else
+
+#define PEPCheckSolved(h,arg) \
+  do { \
+    PetscCheck((h)->state>=PEP_STATE_SOLVED,PetscObjectComm((PetscObject)(h)),PETSC_ERR_ARG_WRONGSTATE,"Must call PEPSolve() first: Parameter #%d",arg); \
+  } while (0)
+
+#endif
+
+/*
+    Macros to check settings at PEPSetUp()
+*/
+
+/* PEPCheckHermitian: the problem is Hermitian or Hyperbolic */
+#define PEPCheckHermitianCondition(pep,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscCheck((pep)->problem_type==PEP_HERMITIAN || (pep)->problem_type==PEP_HYPERBOLIC,PetscObjectComm((PetscObject)(pep)),PETSC_ERR_SUP,"The solver '%s'%s can only be used for Hermitian (or hyperbolic) problems",((PetscObject)(pep))->type_name,(msg)); \
+    } \
+  } while (0)
+#define PEPCheckHermitian(pep) PEPCheckHermitianCondition(pep,PETSC_TRUE,"")
+
+/* PEPCheckQuadratic: the polynomial has degree 2 */
+#define PEPCheckQuadraticCondition(pep,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscCheck((pep)->nmat==3,PetscObjectComm((PetscObject)(pep)),PETSC_ERR_SUP,"The solver '%s'%s is only available for quadratic problems",((PetscObject)(pep))->type_name,(msg)); \
+    } \
+  } while (0)
+#define PEPCheckQuadratic(pep) PEPCheckQuadraticCondition(pep,PETSC_TRUE,"")
+
+/* PEPCheckShiftSinvert: shift or shift-and-invert ST */
+#define PEPCheckShiftSinvertCondition(pep,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscBool __flg; \
+      PetscCall(PetscObjectTypeCompareAny((PetscObject)(pep)->st,&__flg,STSINVERT,STSHIFT,"")); \
+      PetscCheck(__flg,PetscObjectComm((PetscObject)(pep)),PETSC_ERR_SUP,"The solver '%s'%s requires shift or shift-and-invert spectral transform",((PetscObject)(pep))->type_name,(msg)); \
+    } \
+  } while (0)
+#define PEPCheckShiftSinvert(pep) PEPCheckShiftSinvertCondition(pep,PETSC_TRUE,"")
+
+/* PEPCheckSinvertCayley: shift-and-invert or Cayley ST */
+#define PEPCheckSinvertCayleyCondition(pep,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscBool __flg; \
+      PetscCall(PetscObjectTypeCompareAny((PetscObject)(pep)->st,&__flg,STSINVERT,STCAYLEY,"")); \
+      PetscCheck(__flg,PetscObjectComm((PetscObject)(pep)),PETSC_ERR_SUP,"The solver '%s'%s requires shift-and-invert or Cayley transform",((PetscObject)(pep))->type_name,(msg)); \
+    } \
+  } while (0)
+#define PEPCheckSinvertCayley(pep) PEPCheckSinvertCayleyCondition(pep,PETSC_TRUE,"")
+
+/* Check for unsupported features */
+#define PEPCheckUnsupportedCondition(pep,mask,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscCheck(!((mask) & PEP_FEATURE_NONMONOMIAL) || (pep)->basis==PEP_BASIS_MONOMIAL,PetscObjectComm((PetscObject)(pep)),PETSC_ERR_SUP,"The solver '%s'%s is not implemented for non-monomial bases",((PetscObject)(pep))->type_name,(msg)); \
+      if ((mask) & PEP_FEATURE_REGION) { \
+        PetscBool      __istrivial; \
+        PetscCall(RGIsTrivial((pep)->rg,&__istrivial)); \
+        PetscCheck(__istrivial,PetscObjectComm((PetscObject)(pep)),PETSC_ERR_SUP,"The solver '%s'%s does not support region filtering",((PetscObject)(pep))->type_name,(msg)); \
+      } \
+      PetscCheck(!((mask) & PEP_FEATURE_EXTRACT) || !(pep)->extract || (pep)->extract==PEP_EXTRACT_NONE,PetscObjectComm((PetscObject)(pep)),PETSC_ERR_SUP,"The solver '%s'%s does not support extraction variants",((PetscObject)(pep))->type_name,(msg)); \
+      PetscCheck(!((mask) & PEP_FEATURE_CONVERGENCE) || (pep)->converged==PEPConvergedRelative,PetscObjectComm((PetscObject)(pep)),PETSC_ERR_SUP,"The solver '%s'%s only supports the default convergence test",((PetscObject)(pep))->type_name,(msg)); \
+      PetscCheck(!((mask) & PEP_FEATURE_STOPPING) || (pep)->stopping==PEPStoppingBasic,PetscObjectComm((PetscObject)(pep)),PETSC_ERR_SUP,"The solver '%s'%s only supports the default stopping test",((PetscObject)(pep))->type_name,(msg)); \
+    } \
+  } while (0)
+#define PEPCheckUnsupported(pep,mask) PEPCheckUnsupportedCondition(pep,mask,PETSC_TRUE,"")
+
+/* Check for ignored features */
+#define PEPCheckIgnoredCondition(pep,mask,condition,msg) \
+  do { \
+    if (condition) { \
+      if (((mask) & PEP_FEATURE_NONMONOMIAL) && (pep)->basis!=PEP_BASIS_MONOMIAL) PetscCall(PetscInfo((pep),"The solver '%s'%s ignores the basis settings\n",((PetscObject)(pep))->type_name,(msg))); \
+      if ((mask) & PEP_FEATURE_REGION) { \
+        PetscBool __istrivial; \
+        PetscCall(RGIsTrivial((pep)->rg,&__istrivial)); \
+        if (!__istrivial) PetscCall(PetscInfo((pep),"The solver '%s'%s ignores the specified region\n",((PetscObject)(pep))->type_name,(msg))); \
+      } \
+      if (((mask) & PEP_FEATURE_EXTRACT) && (pep)->extract && (pep)->extract!=PEP_EXTRACT_NONE) PetscCall(PetscInfo((pep),"The solver '%s'%s ignores the extract settings\n",((PetscObject)(pep))->type_name,(msg))); \
+      if (((mask) & PEP_FEATURE_CONVERGENCE) && (pep)->converged!=PEPConvergedRelative) PetscCall(PetscInfo((pep),"The solver '%s'%s ignores the convergence test settings\n",((PetscObject)(pep))->type_name,(msg))); \
+      if (((mask) & PEP_FEATURE_STOPPING) && (pep)->stopping!=PEPStoppingBasic) PetscCall(PetscInfo((pep),"The solver '%s'%s ignores the stopping test settings\n",((PetscObject)(pep))->type_name,(msg))); \
+      if (((mask) & PEP_FEATURE_SCALE) && (pep)->scale!=PEP_SCALE_NONE) PetscCall(PetscInfo((pep),"The solver '%s'%s ignores the scaling settings\n",((PetscObject)(pep))->type_name,(msg))); \
+    } \
+  } while (0)
+#define PEPCheckIgnored(pep,mask) PEPCheckIgnoredCondition(pep,mask,PETSC_TRUE,"")
+
+/*
+  PEP_KSPSetOperators - Sets the KSP matrices
+*/
+static inline PetscErrorCode PEP_KSPSetOperators(KSP ksp,Mat A,Mat B)
+{
+  const char     *prefix;
+
+  PetscFunctionBegin;
+  PetscCall(KSPSetOperators(ksp,A,B));
+  PetscCall(MatGetOptionsPrefix(B,&prefix));
+  if (!prefix) {
+    /* set Mat prefix to be the same as KSP to enable setting command-line options (e.g. MUMPS)
+       only applies if the Mat has no user-defined prefix */
+    PetscCall(KSPGetOptionsPrefix(ksp,&prefix));
+    PetscCall(MatSetOptionsPrefix(B,prefix));
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+SLEPC_INTERN PetscErrorCode PEPSetWhichEigenpairs_Default(PEP);
+SLEPC_INTERN PetscErrorCode PEPSetDimensions_Default(PEP,PetscInt,PetscInt*,PetscInt*);
+SLEPC_INTERN PetscErrorCode PEPExtractVectors(PEP);
+SLEPC_INTERN PetscErrorCode PEPBackTransform_Default(PEP);
+SLEPC_INTERN PetscErrorCode PEPComputeVectors(PEP);
+SLEPC_INTERN PetscErrorCode PEPComputeVectors_Default(PEP);
+SLEPC_INTERN PetscErrorCode PEPComputeVectors_Indefinite(PEP);
+SLEPC_INTERN PetscErrorCode PEPComputeResidualNorm_Private(PEP,PetscScalar,PetscScalar,Vec,Vec,Vec*,PetscReal*);
+SLEPC_INTERN PetscErrorCode PEPKrylovConvergence(PEP,PetscBool,PetscInt,PetscInt,PetscReal,PetscInt*);
+SLEPC_INTERN PetscErrorCode PEPComputeScaleFactor(PEP);
+SLEPC_INTERN PetscErrorCode PEPBuildDiagonalScaling(PEP);
+SLEPC_INTERN PetscErrorCode PEPBasisCoefficients(PEP,PetscReal*);
+SLEPC_INTERN PetscErrorCode PEPEvaluateBasis(PEP,PetscScalar,PetscScalar,PetscScalar*,PetscScalar*);
+SLEPC_INTERN PetscErrorCode PEPEvaluateBasisDerivative(PEP,PetscScalar,PetscScalar,PetscScalar*,PetscScalar*);
+SLEPC_INTERN PetscErrorCode PEPEvaluateBasisMat(PEP,PetscInt,PetscScalar*,PetscInt,PetscInt,PetscScalar*,PetscInt,PetscScalar*,PetscInt,PetscScalar*,PetscInt);
+SLEPC_INTERN PetscErrorCode PEPNewtonRefinement_TOAR(PEP,PetscScalar,PetscInt*,PetscReal*,PetscInt,PetscScalar*,PetscInt);
+SLEPC_INTERN PetscErrorCode PEPNewtonRefinementSimple(PEP,PetscInt*,PetscReal,PetscInt);
+SLEPC_INTERN PetscErrorCode PEPSetDefaultST(PEP);
+SLEPC_INTERN PetscErrorCode PEPSetDefaultST_Transform(PEP);

--- a/3rd/slepc/linux/include/slepc/private/rgimpl.h
+++ b/3rd/slepc/linux/include/slepc/private/rgimpl.h
@@ -1,0 +1,44 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepcrg.h>
+#include <slepc/private/slepcimpl.h>
+
+/* SUBMANSEC = RG */
+
+SLEPC_EXTERN PetscBool RGRegisterAllCalled;
+SLEPC_EXTERN PetscErrorCode RGRegisterAll(void);
+
+typedef struct _RGOps *RGOps;
+
+struct _RGOps {
+  PetscErrorCode (*istrivial)(RG,PetscBool*);
+  PetscErrorCode (*computecontour)(RG,PetscInt,PetscScalar*,PetscScalar*);
+  PetscErrorCode (*computebbox)(RG,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
+  PetscErrorCode (*computequadrature)(RG,RGQuadRule,PetscInt,PetscScalar*,PetscScalar*,PetscScalar*);
+  PetscErrorCode (*checkinside)(RG,PetscReal,PetscReal,PetscInt*);
+  PetscErrorCode (*isaxisymmetric)(RG,PetscBool,PetscBool*);
+  PetscErrorCode (*setfromoptions)(RG,PetscOptionItems*);
+  PetscErrorCode (*view)(RG,PetscViewer);
+  PetscErrorCode (*destroy)(RG);
+};
+
+struct _p_RG {
+  PETSCHEADER(struct _RGOps);
+  PetscBool   complement;    /* region is the complement of the specified one */
+  PetscReal   sfactor;       /* scaling factor */
+  PetscReal   osfactor;      /* old scaling factor, before RGPushScale */
+  void        *data;
+};
+
+/* show an inf instead of PETSC_MAX_REAL */
+#define RGShowReal(r) (double)((PetscAbsReal(r)>=PETSC_MAX_REAL)?10*(r):(r))

--- a/3rd/slepc/linux/include/slepc/private/slepccontour.h
+++ b/3rd/slepc/linux/include/slepc/private/slepccontour.h
@@ -1,0 +1,54 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepc/private/slepcimpl.h>
+#include <petscksp.h>
+
+/*
+  CISS_BlockHankel - Builds a block Hankel matrix from the contents of Mu.
+*/
+static inline PetscErrorCode CISS_BlockHankel(PetscScalar *Mu,PetscInt s,PetscInt L,PetscInt M,PetscScalar *H)
+{
+  PetscInt i,j,k;
+
+  PetscFunctionBegin;
+  for (k=0;k<L*M;k++)
+    for (j=0;j<M;j++)
+      for (i=0;i<L;i++)
+        H[j*L+i+k*L*M] = Mu[i+k*L+(j+s)*L*L];
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode SlepcCISS_isGhost(Mat,PetscInt,PetscReal*,PetscReal,PetscBool*);
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode SlepcCISS_BH_SVD(PetscScalar*,PetscInt,PetscReal,PetscReal*,PetscInt*);
+
+/* Data structures and functions for contour integral methods (used in several classes) */
+struct _n_SlepcContourData {
+  PetscObject  parent;     /* parent object */
+  PetscSubcomm subcomm;    /* subcommunicator for top level parallelization */
+  PetscInt     npoints;    /* number of integration points assigned to the local subcomm */
+  KSP          *ksp;       /* ksp array for storing factorizations at integration points */
+  Mat          *pA;        /* redundant copies of the matrices in the local subcomm */
+  Mat          *pP;        /* redundant copies of the matrices (preconditioner) */
+  PetscInt     nmat;       /* number of matrices in pA */
+  Vec          xsub;       /* aux vector with parallel layout as redundant Mat */
+  Vec          xdup;       /* aux vector with parallel layout as original Mat (with contiguous order) */
+  VecScatter   scatterin;  /* to scatter from regular vector to xdup */
+};
+typedef struct _n_SlepcContourData* SlepcContourData;
+
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode SlepcContourDataCreate(PetscInt,PetscInt,PetscObject,SlepcContourData*);
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode SlepcContourDataReset(SlepcContourData);
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode SlepcContourDataDestroy(SlepcContourData*);
+
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode SlepcContourRedundantMat(SlepcContourData,PetscInt,Mat*,Mat*);
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode SlepcContourScatterCreate(SlepcContourData,Vec);

--- a/3rd/slepc/linux/include/slepc/private/slepcimpl.h
+++ b/3rd/slepc/linux/include/slepc/private/slepcimpl.h
@@ -1,0 +1,257 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepcsys.h>
+#include <petsc/private/petscimpl.h>
+
+/* SUBMANSEC = sys */
+
+SLEPC_INTERN PetscBool SlepcBeganPetsc;
+
+/* SlepcSwap - swap two variables a,b of the same type using a temporary variable t */
+#define SlepcSwap(a,b,t) do {t=a;a=b;b=t;} while (0)
+
+/*MC
+    SlepcHeaderCreate - Creates a SLEPc object
+
+    Input Parameters:
++   classid - the classid associated with this object
+.   class_name - string name of class; should be static
+.   descr - string containing short description; should be static
+.   mansec - string indicating section in manual pages; should be static
+.   comm - the MPI Communicator
+.   destroy - the destroy routine for this object
+-   view - the view routine for this object
+
+    Output Parameter:
+.   h - the newly created object
+
+    Note:
+    This is equivalent to PetscHeaderCreate but makes sure that SlepcInitialize
+    has been called.
+
+    Level: developer
+M*/
+#define SlepcHeaderCreate(h,classid,class_name,descr,mansec,comm,destroy,view) \
+    ((PetscErrorCode)((!SlepcInitializeCalled && \
+                       PetscError(comm,__LINE__,PETSC_FUNCTION_NAME,__FILE__,PETSC_ERR_ORDER,PETSC_ERROR_INITIAL, \
+                                  "Must call SlepcInitialize instead of PetscInitialize to use SLEPc classes")) || \
+                      PetscHeaderCreate(h,classid,class_name,descr,mansec,comm,destroy,view)))
+
+/* context for monitors of type XXXMonitorConverged */
+struct _n_SlepcConvMon {
+  void     *ctx;
+  PetscInt oldnconv;  /* previous value of nconv */
+};
+
+/* context for structured eigenproblem matrices created via MatCreateXXX */
+struct _n_SlepcMatStruct {
+  PetscInt cookie;    /* identify which structured matrix */
+};
+typedef struct _n_SlepcMatStruct* SlepcMatStruct;
+
+#define SLEPC_MAT_STRUCT_BSE 88101
+
+/*
+  SlepcCheckMatStruct - Check that a given Mat is a structured matrix of the wanted type.
+
+  Returns true/false in flg if it is given, otherwise yields an error if the check fails.
+  If cookie==0 it will check for any type.
+*/
+static inline PetscErrorCode SlepcCheckMatStruct(Mat A,PetscInt cookie,PetscBool *flg)
+{
+  PetscContainer container;
+  SlepcMatStruct mctx;
+
+  PetscFunctionBegin;
+  if (flg) *flg = PETSC_FALSE;
+  PetscCall(PetscObjectQuery((PetscObject)A,"SlepcMatStruct",(PetscObject*)&container));
+  if (flg && !container) PetscFunctionReturn(PETSC_SUCCESS);
+  PetscCheck(container,PetscObjectComm((PetscObject)A),PETSC_ERR_ARG_WRONG,"The Mat is not a structured matrix");
+  if (cookie) {
+    PetscCall(PetscContainerGetPointer(container,(void**)&mctx));
+    if (flg && (!mctx || mctx->cookie!=cookie)) PetscFunctionReturn(PETSC_SUCCESS);
+    PetscCheck(mctx && mctx->cookie==cookie,PetscObjectComm((PetscObject)A),PETSC_ERR_ARG_WRONG,"The type of structured matrix is different from the expected one");
+  }
+  if (flg) *flg = PETSC_TRUE;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+  SlepcPrintEigenvalueASCII - Print an eigenvalue on an ASCII viewer.
+*/
+static inline PetscErrorCode SlepcPrintEigenvalueASCII(PetscViewer viewer,PetscScalar eigr,PetscScalar eigi)
+{
+  PetscReal      re,im;
+
+  PetscFunctionBegin;
+#if defined(PETSC_USE_COMPLEX)
+  re = PetscRealPart(eigr);
+  im = PetscImaginaryPart(eigr);
+  (void)eigi;
+#else
+  re = eigr;
+  im = eigi;
+#endif
+  /* print zero instead of tiny value */
+  if (PetscAbs(im) && PetscAbs(re)/PetscAbs(im)<PETSC_SMALL) re = 0.0;
+  if (PetscAbs(re) && PetscAbs(im)/PetscAbs(re)<PETSC_SMALL) im = 0.0;
+  /* print as real if imaginary part is zero */
+  if (im!=(PetscReal)0.0) PetscCall(PetscViewerASCIIPrintf(viewer,"%.5f%+.5fi",(double)re,(double)im));
+  else PetscCall(PetscViewerASCIIPrintf(viewer,"%.5f",(double)re));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+  SlepcViewEigenvector - Outputs an eigenvector xr,xi to a viewer.
+  In complex scalars only xr is written.
+  The name of xr,xi is set before writing, based on the label, the index, and the name of obj.
+*/
+static inline PetscErrorCode SlepcViewEigenvector(PetscViewer viewer,Vec xr,Vec xi,const char *label,PetscInt index,PetscObject obj)
+{
+  size_t         count;
+  char           vname[30];
+  const char     *pname;
+
+  PetscFunctionBegin;
+  PetscCall(PetscObjectGetName(obj,&pname));
+  PetscCall(PetscSNPrintfCount(vname,sizeof(vname),"%s%s",&count,label,PetscDefined(USE_COMPLEX)?"":"r"));
+  count--;
+  PetscCall(PetscSNPrintf(vname+count,sizeof(vname)-count,"%" PetscInt_FMT "_%s",index,pname));
+  PetscCall(PetscObjectSetName((PetscObject)xr,vname));
+  PetscCall(VecView(xr,viewer));
+#if !defined(PETSC_USE_COMPLEX)
+  vname[count-1] = 'i';
+  PetscCall(PetscObjectSetName((PetscObject)xi,vname));
+  PetscCall(VecView(xi,viewer));
+#else
+  (void)xi;
+#endif
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/* Macros for strings with different value in real and complex */
+#if defined(PETSC_USE_COMPLEX)
+#define SLEPC_STRING_HERMITIAN "hermitian"
+#else
+#define SLEPC_STRING_HERMITIAN "symmetric"
+#endif
+
+/* Private functions that are shared by several classes */
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode SlepcBasisReference_Private(PetscInt,Vec*,PetscInt*,Vec**);
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode SlepcBasisDestroy_Private(PetscInt*,Vec**);
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode SlepcMonitorMakeKey_Internal(const char[],PetscViewerType,PetscViewerFormat,char[]);
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode PetscViewerAndFormatCreate_Internal(PetscViewer,PetscViewerFormat,void*,PetscViewerAndFormat**);
+
+SLEPC_INTERN PetscErrorCode SlepcCitationsInitialize(void);
+SLEPC_INTERN PetscErrorCode SlepcInitialize_DynamicLibraries(void);
+SLEPC_INTERN PetscErrorCode SlepcInitialize_Packages(void);
+
+/* Macro to check a sequential Mat (including GPU) */
+#if !defined(PETSC_USE_DEBUG)
+#define SlepcMatCheckSeq(h) do {(void)(h);} while (0)
+#else
+#if defined(PETSC_HAVE_CUDA)
+#define SlepcMatCheckSeq(h) do { PetscCheckTypeNames((h),MATSEQDENSE,MATSEQDENSECUDA); } while (0)
+#elif defined(PETSC_HAVE_HIP)
+#define SlepcMatCheckSeq(h) do { PetscCheckTypeNames((h),MATSEQDENSE,MATSEQDENSEHIP); } while (0)
+#else
+#define SlepcMatCheckSeq(h) do { PetscCheckTypeName((h),MATSEQDENSE); } while (0)
+#endif
+#endif
+
+/* Definitions needed to work with GPU kernels */
+#if defined(PETSC_HAVE_CUPM)
+#include <petscdevice_cupm.h>
+
+#define X_AXIS 0
+#define Y_AXIS 1
+
+#define SLEPC_TILE_SIZE_X  32
+#define SLEPC_BLOCK_SIZE_X 128
+#define SLEPC_TILE_SIZE_Y  32
+#define SLEPC_BLOCK_SIZE_Y 128
+
+static inline PetscErrorCode SlepcKernelSetGrid1D(PetscInt rows,dim3 *dimGrid,dim3 *dimBlock,PetscInt *dimGrid_xcount)
+{
+  int card;
+#if defined(PETSC_HAVE_CUDA)
+  struct cudaDeviceProp devprop;
+#elif defined(PETSC_HAVE_HIP)
+  hipDeviceProp_t devprop;
+#endif
+
+  PetscFunctionBegin;
+#if defined(PETSC_HAVE_CUDA)
+  PetscCallCUDA(cudaGetDevice(&card));
+  PetscCallCUDA(cudaGetDeviceProperties(&devprop,card));
+#elif defined(PETSC_HAVE_HIP)
+  PetscCallHIP(hipGetDevice(&card));
+  PetscCallHIP(hipGetDeviceProperties(&devprop,card));
+#endif
+  *dimGrid_xcount = 1;
+
+  /* X axis */
+  dimGrid->x  = 1;
+  dimBlock->x = SLEPC_BLOCK_SIZE_X;
+  if (rows>SLEPC_BLOCK_SIZE_X) dimGrid->x = (rows+SLEPC_BLOCK_SIZE_X-1)/SLEPC_BLOCK_SIZE_X;
+  else dimBlock->x = rows;
+  if (dimGrid->x>(unsigned)devprop.maxGridSize[X_AXIS]) {
+    *dimGrid_xcount = (dimGrid->x+(devprop.maxGridSize[X_AXIS]-1))/devprop.maxGridSize[X_AXIS];
+    dimGrid->x = devprop.maxGridSize[X_AXIS];
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+static inline PetscErrorCode SlepcKernelSetGrid2DTiles(PetscInt rows,PetscInt cols,dim3 *dimGrid,dim3 *dimBlock,PetscInt *dimGrid_xcount,PetscInt *dimGrid_ycount)
+{
+  int card;
+#if defined(PETSC_HAVE_CUDA)
+  struct cudaDeviceProp devprop;
+#elif defined(PETSC_HAVE_HIP)
+  hipDeviceProp_t devprop;
+#endif
+
+  PetscFunctionBegin;
+#if defined(PETSC_HAVE_CUDA)
+  PetscCallCUDA(cudaGetDevice(&card));
+  PetscCallCUDA(cudaGetDeviceProperties(&devprop,card));
+#elif defined(PETSC_HAVE_HIP)
+  PetscCallHIP(hipGetDevice(&card));
+  PetscCallHIP(hipGetDeviceProperties(&devprop,card));
+#endif
+  *dimGrid_xcount = *dimGrid_ycount = 1;
+
+  /* X axis */
+  dimGrid->x  = 1;
+  dimBlock->x = SLEPC_BLOCK_SIZE_X;
+  if (rows>SLEPC_BLOCK_SIZE_X*SLEPC_TILE_SIZE_X) dimGrid->x = (rows+SLEPC_BLOCK_SIZE_X*SLEPC_TILE_SIZE_X-1)/(SLEPC_BLOCK_SIZE_X*SLEPC_TILE_SIZE_X);
+  else dimBlock->x = (rows+SLEPC_TILE_SIZE_X-1)/SLEPC_TILE_SIZE_X;
+  if (dimGrid->x>(unsigned)devprop.maxGridSize[X_AXIS]) {
+    *dimGrid_xcount = (dimGrid->x+(devprop.maxGridSize[X_AXIS]-1))/devprop.maxGridSize[X_AXIS];
+    dimGrid->x = devprop.maxGridSize[X_AXIS];
+  }
+
+  /* Y axis */
+  dimGrid->y  = 1;
+  dimBlock->y = SLEPC_BLOCK_SIZE_Y;
+  if (cols>SLEPC_BLOCK_SIZE_Y*SLEPC_TILE_SIZE_Y) dimGrid->y = (cols+SLEPC_BLOCK_SIZE_Y*SLEPC_TILE_SIZE_Y-1)/(SLEPC_BLOCK_SIZE_Y*SLEPC_TILE_SIZE_Y);
+  else dimBlock->y = (cols+SLEPC_TILE_SIZE_Y-1)/SLEPC_TILE_SIZE_Y;
+  if (dimGrid->y>(unsigned)devprop.maxGridSize[Y_AXIS]) {
+    *dimGrid_ycount = (dimGrid->y+(devprop.maxGridSize[Y_AXIS]-1))/devprop.maxGridSize[Y_AXIS];
+    dimGrid->y = devprop.maxGridSize[Y_AXIS];
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+#undef X_AXIS
+#undef Y_AXIS
+#endif

--- a/3rd/slepc/linux/include/slepc/private/slepcscalapack.h
+++ b/3rd/slepc/linux/include/slepc/private/slepcscalapack.h
@@ -1,0 +1,34 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepcsys.h>
+#include <petsc/private/petscscalapack.h>
+
+/* ScaLAPACK routines */
+#define SCALAPACKgesvd_   PETSCSCALAPACK(gesvd,GESVD)
+#if defined(PETSC_USE_COMPLEX)
+#define SCALAPACKsyev_    PETSCSCALAPACK(heev,HEEV)
+#define SCALAPACKsygvx_   PETSCSCALAPACK(hegvx,HEGVX)
+#else
+#define SCALAPACKsyev_    PETSCSCALAPACK(syev,SYEV)
+#define SCALAPACKsygvx_   PETSCSCALAPACK(sygvx,SYGVX)
+#endif
+
+#if defined(PETSC_USE_COMPLEX)
+BLAS_EXTERN PetscReal SCALAPACKgesvd_(const char*,const char*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscReal*,PetscBLASInt*);
+BLAS_EXTERN PetscReal SCALAPACKsyev_(const char*,const char*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscBLASInt*);
+BLAS_EXTERN PetscReal SCALAPACKsygvx_(PetscBLASInt*,const char*,const char*,const char*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscReal*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscBLASInt*);
+#else
+BLAS_EXTERN PetscReal SCALAPACKgesvd_(const char*,const char*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*);
+BLAS_EXTERN PetscReal SCALAPACKsyev_(const char*,const char*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*);
+BLAS_EXTERN PetscReal SCALAPACKsygvx_(PetscBLASInt*,const char*,const char*,const char*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscReal*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscBLASInt*);
+#endif

--- a/3rd/slepc/linux/include/slepc/private/stimpl.h
+++ b/3rd/slepc/linux/include/slepc/private/stimpl.h
@@ -1,0 +1,147 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepcst.h>
+#include <slepc/private/slepcimpl.h>
+
+/* SUBMANSEC = ST */
+
+SLEPC_EXTERN PetscBool STRegisterAllCalled;
+SLEPC_EXTERN PetscErrorCode STRegisterAll(void);
+SLEPC_EXTERN PetscLogEvent ST_SetUp,ST_ComputeOperator,ST_Apply,ST_ApplyTranspose,ST_ApplyHermitianTranspose,ST_MatSetUp,ST_MatMult,ST_MatMultTranspose,ST_MatSolve,ST_MatSolveTranspose;
+
+typedef struct _STOps *STOps;
+
+struct _STOps {
+  PetscErrorCode (*apply)(ST,Vec,Vec);
+  PetscErrorCode (*applymat)(ST,Mat,Mat);
+  PetscErrorCode (*applytrans)(ST,Vec,Vec);
+  PetscErrorCode (*applyhermtrans)(ST,Vec,Vec);
+  PetscErrorCode (*backtransform)(ST,PetscInt,PetscScalar*,PetscScalar*);
+  PetscErrorCode (*setshift)(ST,PetscScalar);
+  PetscErrorCode (*getbilinearform)(ST,Mat*);
+  PetscErrorCode (*setup)(ST);
+  PetscErrorCode (*computeoperator)(ST);
+  PetscErrorCode (*setfromoptions)(ST,PetscOptionItems*);
+  PetscErrorCode (*postsolve)(ST);
+  PetscErrorCode (*destroy)(ST);
+  PetscErrorCode (*reset)(ST);
+  PetscErrorCode (*view)(ST,PetscViewer);
+  PetscErrorCode (*checknullspace)(ST,BV);
+  PetscErrorCode (*setdefaultksp)(ST);
+};
+
+/*
+     'Updated' state means STSetUp must be called because matrices have been
+     modified, but the pattern is the same (hence reuse symbolic factorization)
+*/
+typedef enum { ST_STATE_INITIAL,
+               ST_STATE_SETUP,
+               ST_STATE_UPDATED } STStateType;
+
+struct _p_ST {
+  PETSCHEADER(struct _STOps);
+  /*------------------------- User parameters --------------------------*/
+  Mat              *A;               /* matrices that define the eigensystem */
+  PetscInt         nmat;             /* number of user-provided matrices */
+  PetscScalar      sigma;            /* value of the shift */
+  PetscScalar      defsigma;         /* default value of the shift */
+  STMatMode        matmode;          /* how the transformation matrix is handled */
+  MatStructure     str;              /* whether matrices have the same pattern or not */
+  PetscBool        transform;        /* whether transformed matrices are computed */
+  PetscBool        structured;       /* whether the operator is structured or not */
+  Vec              D;                /* diagonal matrix for balancing */
+  Mat              Pmat;             /* user-provided preconditioner matrix */
+  PetscBool        Pmat_set;         /* whether the user provided a preconditioner matrix or not  */
+  Mat              *Psplit;          /* matrices for the split preconditioner */
+  PetscInt         nsplit;           /* number of split preconditioner matrices */
+  MatStructure     strp;             /* pattern of split preconditioner matrices */
+
+  /*------------------------- Misc data --------------------------*/
+  KSP              ksp;              /* linear solver used in some ST's */
+  PetscBool        usesksp;          /* whether the KSP object is used or not */
+  PetscInt         nwork;            /* number of work vectors */
+  Vec              *work;            /* work vectors */
+  Vec              wb;               /* balancing requires an extra work vector */
+  Vec              wht;              /* extra work vector for hermitian transpose apply */
+  STStateType      state;            /* initial -> setup -> with updated matrices */
+  PetscObjectState *Astate;          /* matrix state (to identify the original matrices) */
+  Mat              *T;               /* matrices resulting from transformation */
+  Mat              Op;               /* shell matrix for operator = alpha*D*inv(P)*M*inv(D) */
+  PetscBool        opseized;         /* whether Op has been seized by user */
+  PetscBool        opready;          /* whether Op is up-to-date or need be computed  */
+  Mat              P;                /* matrix from which preconditioner is built */
+  Mat              M;                /* matrix corresponding to the non-inverted part of the operator */
+  PetscBool        sigma_set;        /* whether the user provided the shift or not */
+  PetscBool        asymm;            /* the user matrices are all symmetric */
+  PetscBool        aherm;            /* the user matrices are all hermitian */
+  void             *data;
+};
+
+/*
+    Macros to test valid ST arguments
+*/
+#if !defined(PETSC_USE_DEBUG)
+
+#define STCheckMatrices(h,arg) do {(void)(h);} while (0)
+#define STCheckNotSeized(h,arg) do {(void)(h);} while (0)
+
+#else
+
+#define STCheckMatrices(h,arg) \
+  do { \
+    PetscCheck((h)->A,PetscObjectComm((PetscObject)(h)),PETSC_ERR_ARG_WRONGSTATE,"ST matrices have not been set: Parameter #%d",arg); \
+  } while (0)
+#define STCheckNotSeized(h,arg) \
+  do { \
+    PetscCheck(!(h)->opseized,PetscObjectComm((PetscObject)(h)),PETSC_ERR_ARG_WRONGSTATE,"Must call STRestoreOperator() first: Parameter #%d",arg); \
+  } while (0)
+
+#endif
+
+SLEPC_INTERN PetscErrorCode STGetBilinearForm_Default(ST,Mat*);
+SLEPC_INTERN PetscErrorCode STCheckNullSpace_Default(ST,BV);
+SLEPC_INTERN PetscErrorCode STMatShellCreate(ST,PetscScalar,PetscInt,PetscInt*,PetscScalar*,Mat*);
+SLEPC_INTERN PetscErrorCode STMatShellShift(Mat,PetscScalar);
+SLEPC_INTERN PetscErrorCode STCheckFactorPackage(ST);
+SLEPC_INTERN PetscErrorCode STMatMAXPY_Private(ST,PetscScalar,PetscScalar,PetscInt,PetscScalar*,PetscBool,PetscBool,Mat*);
+SLEPC_INTERN PetscErrorCode STCoeffs_Monomial(ST,PetscScalar*);
+SLEPC_INTERN PetscErrorCode STSetDefaultKSP(ST);
+SLEPC_INTERN PetscErrorCode STSetDefaultKSP_Default(ST);
+SLEPC_INTERN PetscErrorCode STIsInjective_Shell(ST,PetscBool*);
+SLEPC_INTERN PetscErrorCode STComputeOperator(ST);
+SLEPC_INTERN PetscErrorCode STGetOperator_Private(ST,Mat*);
+SLEPC_INTERN PetscErrorCode STApply_Generic(ST,Vec,Vec);
+SLEPC_INTERN PetscErrorCode STApplyMat_Generic(ST,Mat,Mat);
+SLEPC_INTERN PetscErrorCode STApplyTranspose_Generic(ST,Vec,Vec);
+SLEPC_INTERN PetscErrorCode STApplyHermitianTranspose_Generic(ST,Vec,Vec);
+
+/*
+  ST_KSPSetOperators - Sets the KSP matrices
+*/
+static inline PetscErrorCode ST_KSPSetOperators(ST st,Mat A,Mat B)
+{
+  const char     *prefix;
+
+  PetscFunctionBegin;
+  if (!st->ksp) PetscCall(STGetKSP(st,&st->ksp));
+  PetscCall(STCheckFactorPackage(st));
+  PetscCall(KSPSetOperators(st->ksp,A,B));
+  PetscCall(MatGetOptionsPrefix(B,&prefix));
+  if (!prefix) {
+    /* set Mat prefix to be the same as KSP to enable setting command-line options (e.g. MUMPS)
+       only applies if the Mat has no user-defined prefix */
+    PetscCall(KSPGetOptionsPrefix(st->ksp,&prefix));
+    PetscCall(MatSetOptionsPrefix(B,prefix));
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}

--- a/3rd/slepc/linux/include/slepc/private/svdimpl.h
+++ b/3rd/slepc/linux/include/slepc/private/svdimpl.h
@@ -1,0 +1,228 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepcsvd.h>
+#include <slepc/private/slepcimpl.h>
+
+/* SUBMANSEC = SVD */
+
+SLEPC_EXTERN PetscBool SVDRegisterAllCalled;
+SLEPC_EXTERN PetscBool SVDMonitorRegisterAllCalled;
+SLEPC_EXTERN PetscErrorCode SVDRegisterAll(void);
+SLEPC_EXTERN PetscErrorCode SVDMonitorRegisterAll(void);
+SLEPC_EXTERN PetscLogEvent SVD_SetUp,SVD_Solve;
+
+typedef struct _SVDOps *SVDOps;
+
+struct _SVDOps {
+  PetscErrorCode (*solve)(SVD);
+  PetscErrorCode (*solveg)(SVD);
+  PetscErrorCode (*solveh)(SVD);
+  PetscErrorCode (*setup)(SVD);
+  PetscErrorCode (*setfromoptions)(SVD,PetscOptionItems*);
+  PetscErrorCode (*publishoptions)(SVD);
+  PetscErrorCode (*destroy)(SVD);
+  PetscErrorCode (*reset)(SVD);
+  PetscErrorCode (*view)(SVD,PetscViewer);
+  PetscErrorCode (*computevectors)(SVD);
+  PetscErrorCode (*setdstype)(SVD);
+};
+
+/*
+     Maximum number of monitors you can run with a single SVD
+*/
+#define MAXSVDMONITORS 5
+
+typedef enum { SVD_STATE_INITIAL,
+               SVD_STATE_SETUP,
+               SVD_STATE_SOLVED,
+               SVD_STATE_VECTORS } SVDStateType;
+
+/*
+   To check for unsupported features at SVDSetUp_XXX()
+*/
+typedef enum { SVD_FEATURE_CONVERGENCE=16,  /* convergence test selected by user */
+               SVD_FEATURE_STOPPING=32      /* stopping test */
+             } SVDFeatureType;
+
+/*
+   Defines the SVD data structure.
+*/
+struct _p_SVD {
+  PETSCHEADER(struct _SVDOps);
+  /*------------------------- User parameters ---------------------------*/
+  Mat            OP,OPb;           /* problem matrices */
+  Vec            omega;            /* signature for hyperbolic problems */
+  PetscInt       max_it;           /* max iterations */
+  PetscInt       nsv;              /* number of requested values */
+  PetscInt       ncv;              /* basis size */
+  PetscInt       mpd;              /* maximum dimension of projected problem */
+  PetscInt       nini,ninil;       /* number of initial vecs (negative means not copied yet) */
+  PetscReal      tol;              /* tolerance */
+  SVDConv        conv;             /* convergence test */
+  SVDStop        stop;             /* stopping test */
+  SVDWhich       which;            /* which singular values are computed */
+  SVDProblemType problem_type;     /* which kind of problem to be solved */
+  PetscBool      impltrans;        /* implicit transpose mode */
+  PetscBool      trackall;         /* whether all the residuals must be computed */
+
+  /*-------------- User-provided functions and contexts -----------------*/
+  SVDConvergenceTestFn *converged;
+  SVDConvergenceTestFn *convergeduser;
+  PetscErrorCode       (*convergeddestroy)(void*);
+  SVDStoppingTestFn    *stopping;
+  SVDStoppingTestFn    *stoppinguser;
+  PetscErrorCode       (*stoppingdestroy)(void*);
+  void           *convergedctx;
+  void           *stoppingctx;
+  PetscErrorCode (*monitor[MAXSVDMONITORS])(SVD,PetscInt,PetscInt,PetscReal*,PetscReal*,PetscInt,void*);
+  PetscErrorCode (*monitordestroy[MAXSVDMONITORS])(void**);
+  void           *monitorcontext[MAXSVDMONITORS];
+  PetscInt       numbermonitors;
+
+  /*----------------- Child objects and working data -------------------*/
+  DS             ds;               /* direct solver object */
+  BV             U,V;              /* left and right singular vectors */
+  SlepcSC        sc;               /* sorting criterion data */
+  Mat            A,B;              /* problem matrices */
+  Mat            AT,BT;            /* transposed matrices */
+  Vec            *IS,*ISL;         /* placeholder for references to user initial space */
+  PetscReal      *sigma;           /* singular values */
+  PetscReal      *errest;          /* error estimates */
+  PetscReal      *sign;            /* +-1 for each singular value in hyperbolic problems=U'*Omega*U */
+  PetscInt       *perm;            /* permutation for singular value ordering */
+  PetscInt       nworkl,nworkr;    /* number of work vectors */
+  Vec            *workl,*workr;    /* work vectors */
+  void           *data;            /* placeholder for solver-specific stuff */
+
+  /* ----------------------- Status variables -------------------------- */
+  SVDStateType   state;            /* initial -> setup -> solved -> vectors */
+  PetscInt       nconv;            /* number of converged values */
+  PetscInt       its;              /* iteration counter */
+  PetscBool      leftbasis;        /* if U is filled by the solver */
+  PetscBool      swapped;          /* the U and V bases have been swapped (M<N) */
+  PetscBool      expltrans;        /* explicit transpose created */
+  PetscReal      nrma,nrmb;        /* computed matrix norms */
+  PetscBool      isgeneralized;
+  PetscBool      ishyperbolic;
+  SVDConvergedReason reason;
+};
+
+/*
+    Macros to test valid SVD arguments
+*/
+#if !defined(PETSC_USE_DEBUG)
+
+#define SVDCheckSolved(h,arg) do {(void)(h);} while (0)
+
+#else
+
+#define SVDCheckSolved(h,arg) \
+  do { \
+    PetscCheck((h)->state>=SVD_STATE_SOLVED,PetscObjectComm((PetscObject)(h)),PETSC_ERR_ARG_WRONGSTATE,"Must call SVDSolve() first: Parameter #%d",arg); \
+  } while (0)
+
+#endif
+
+/*
+    Macros to check settings at SVDSetUp()
+*/
+
+/* SVDCheckStandard: the problem is not GSVD */
+#define SVDCheckStandardCondition(svd,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscCheck(!(svd)->isgeneralized,PetscObjectComm((PetscObject)(svd)),PETSC_ERR_SUP,"The solver '%s'%s cannot be used for generalized problems",((PetscObject)(svd))->type_name,(msg)); \
+    } \
+  } while (0)
+#define SVDCheckStandard(svd) SVDCheckStandardCondition(svd,PETSC_TRUE,"")
+
+/* SVDCheckDefinite: the problem is not hyperbolic */
+#define SVDCheckDefiniteCondition(svd,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscCheck(!(svd)->ishyperbolic,PetscObjectComm((PetscObject)(svd)),PETSC_ERR_SUP,"The solver '%s'%s cannot be used for hyperbolic problems",((PetscObject)(svd))->type_name,(msg)); \
+    } \
+  } while (0)
+#define SVDCheckDefinite(svd) SVDCheckDefiniteCondition(svd,PETSC_TRUE,"")
+
+/* Check for unsupported features */
+#define SVDCheckUnsupportedCondition(svd,mask,condition,msg) \
+  do { \
+    if (condition) { \
+      PetscCheck(!((mask) & SVD_FEATURE_CONVERGENCE) || (svd)->converged==SVDConvergedRelative,PetscObjectComm((PetscObject)(svd)),PETSC_ERR_SUP,"The solver '%s'%s only supports the default convergence test",((PetscObject)(svd))->type_name,(msg)); \
+      PetscCheck(!((mask) & SVD_FEATURE_STOPPING) || (svd)->stopping==SVDStoppingBasic,PetscObjectComm((PetscObject)(svd)),PETSC_ERR_SUP,"The solver '%s'%s only supports the default stopping test",((PetscObject)(svd))->type_name,(msg)); \
+    } \
+  } while (0)
+#define SVDCheckUnsupported(svd,mask) SVDCheckUnsupportedCondition(svd,mask,PETSC_TRUE,"")
+
+/* Check for ignored features */
+#define SVDCheckIgnoredCondition(svd,mask,condition,msg) \
+  do { \
+    if (condition) { \
+      if (((mask) & SVD_FEATURE_CONVERGENCE) && (svd)->converged!=SVDConvergedRelative) PetscCall(PetscInfo((svd),"The solver '%s'%s ignores the convergence test settings\n",((PetscObject)(svd))->type_name,(msg))); \
+      if (((mask) & SVD_FEATURE_STOPPING) && (svd)->stopping!=SVDStoppingBasic) PetscCall(PetscInfo((svd),"The solver '%s'%s ignores the stopping test settings\n",((PetscObject)(svd))->type_name,(msg))); \
+    } \
+  } while (0)
+#define SVDCheckIgnored(svd,mask) SVDCheckIgnoredCondition(svd,mask,PETSC_TRUE,"")
+
+/*
+  SVD_KSPSetOperators - Sets the KSP matrices
+*/
+static inline PetscErrorCode SVD_KSPSetOperators(KSP ksp,Mat A,Mat B)
+{
+  const char     *prefix;
+
+  PetscFunctionBegin;
+  PetscCall(KSPSetOperators(ksp,A,B));
+  PetscCall(MatGetOptionsPrefix(B,&prefix));
+  if (!prefix) {
+    /* set Mat prefix to be the same as KSP to enable setting command-line options (e.g. MUMPS)
+       only applies if the Mat has no user-defined prefix */
+    PetscCall(KSPGetOptionsPrefix(ksp,&prefix));
+    PetscCall(MatSetOptionsPrefix(B,prefix));
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   Create the template vector for the left basis in GSVD, as in
+   MatCreateVecsEmpty(Z,NULL,&t) for Z=[A;B] without forming Z.
+ */
+static inline PetscErrorCode SVDCreateLeftTemplate(SVD svd,Vec *t)
+{
+  PetscInt       M,P,m,p;
+  Vec            v1,v2;
+  VecType        vec_type;
+
+  PetscFunctionBegin;
+  PetscCall(MatCreateVecsEmpty(svd->OP,NULL,&v1));
+  PetscCall(VecGetSize(v1,&M));
+  PetscCall(VecGetLocalSize(v1,&m));
+  PetscCall(VecGetType(v1,&vec_type));
+  PetscCall(MatCreateVecsEmpty(svd->OPb,NULL,&v2));
+  PetscCall(VecGetSize(v2,&P));
+  PetscCall(VecGetLocalSize(v2,&p));
+  PetscCall(VecCreate(PetscObjectComm((PetscObject)(v1)),t));
+  PetscCall(VecSetType(*t,vec_type));
+  PetscCall(VecSetSizes(*t,m+p,M+P));
+  PetscCall(VecSetUp(*t));
+  PetscCall(VecDestroy(&v1));
+  PetscCall(VecDestroy(&v2));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+SLEPC_INTERN PetscErrorCode SVDKrylovConvergence(SVD,PetscBool,PetscInt,PetscInt,PetscReal,PetscInt*);
+SLEPC_INTERN PetscErrorCode SVDTwoSideLanczos(SVD,PetscReal*,PetscReal*,BV,BV,PetscInt,PetscInt*,PetscBool*);
+SLEPC_INTERN PetscErrorCode SVDSetDimensions_Default(SVD);
+SLEPC_INTERN PetscErrorCode SVDComputeVectors(SVD);
+SLEPC_INTERN PetscErrorCode SVDComputeVectors_Left(SVD);

--- a/3rd/slepc/linux/include/slepc/private/vecimplslepc.h
+++ b/3rd/slepc/linux/include/slepc/private/vecimplslepc.h
@@ -1,0 +1,97 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+#include <slepcvec.h>
+#include <slepc/private/slepcimpl.h>
+
+/* SUBMANSEC = sys */
+
+#if !defined(PETSC_USE_DEBUG)
+
+#define SlepcValidVecComp(y,arg) do {(void)(y);} while (0)
+
+#else
+
+#define SlepcValidVecComp(y,arg) \
+  do { \
+    PetscCheck(((Vec_Comp*)(y)->data)->nx>=((Vec_Comp*)(y)->data)->n->n,PETSC_COMM_SELF,PETSC_ERR_ARG_WRONGSTATE,"Invalid number of subvectors required: Parameter #%d",arg); \
+  } while (0)
+
+#endif
+
+/* Contexts for VecComp */
+typedef struct {
+  PetscInt      n;        /* number of active subvectors */
+  PetscInt      N;        /* virtual global size */
+  PetscInt      lN;       /* virtual local size */
+  PetscInt      friends;  /* number of vectors sharing this structure */
+} Vec_Comp_N;
+
+typedef struct {
+  Vec           *x;       /* the vectors */
+  PetscInt      nx;       /* number of available subvectors */
+  Vec_Comp_N    *n;       /* structure shared by friend vectors */
+} Vec_Comp;
+
+/* Operations implemented in VecComp */
+SLEPC_INTERN PetscErrorCode VecDuplicateVecs_Comp(Vec,PetscInt,Vec*[]);
+SLEPC_INTERN PetscErrorCode VecDestroyVecs_Comp(PetscInt,Vec[]);
+SLEPC_INTERN PetscErrorCode VecDuplicate_Comp(Vec,Vec*);
+SLEPC_INTERN PetscErrorCode VecDestroy_Comp(Vec);
+SLEPC_INTERN PetscErrorCode VecSet_Comp(Vec,PetscScalar);
+SLEPC_INTERN PetscErrorCode VecView_Comp(Vec,PetscViewer);
+SLEPC_INTERN PetscErrorCode VecScale_Comp(Vec,PetscScalar);
+SLEPC_INTERN PetscErrorCode VecCopy_Comp(Vec,Vec);
+SLEPC_INTERN PetscErrorCode VecSwap_Comp(Vec,Vec);
+SLEPC_INTERN PetscErrorCode VecAXPY_Comp(Vec,PetscScalar,Vec);
+SLEPC_INTERN PetscErrorCode VecAYPX_Comp(Vec,PetscScalar,Vec);
+SLEPC_INTERN PetscErrorCode VecAXPBY_Comp(Vec,PetscScalar,PetscScalar,Vec);
+SLEPC_INTERN PetscErrorCode VecMAXPY_Comp(Vec,PetscInt,const PetscScalar*,Vec*);
+SLEPC_INTERN PetscErrorCode VecWAXPY_Comp(Vec,PetscScalar,Vec,Vec);
+SLEPC_INTERN PetscErrorCode VecAXPBYPCZ_Comp(Vec,PetscScalar,PetscScalar,PetscScalar,Vec,Vec);
+SLEPC_INTERN PetscErrorCode VecPointwiseMult_Comp(Vec,Vec,Vec);
+SLEPC_INTERN PetscErrorCode VecPointwiseDivide_Comp(Vec,Vec,Vec);
+SLEPC_INTERN PetscErrorCode VecGetSize_Comp(Vec,PetscInt*);
+SLEPC_INTERN PetscErrorCode VecGetLocalSize_Comp(Vec,PetscInt*);
+SLEPC_INTERN PetscErrorCode VecMax_Comp(Vec,PetscInt*,PetscReal*);
+SLEPC_INTERN PetscErrorCode VecMin_Comp(Vec,PetscInt*,PetscReal*);
+SLEPC_INTERN PetscErrorCode VecSetRandom_Comp(Vec,PetscRandom);
+SLEPC_INTERN PetscErrorCode VecConjugate_Comp(Vec);
+SLEPC_INTERN PetscErrorCode VecReciprocal_Comp(Vec);
+SLEPC_INTERN PetscErrorCode VecMaxPointwiseDivide_Comp(Vec,Vec,PetscReal*);
+SLEPC_INTERN PetscErrorCode VecPointwiseMax_Comp(Vec,Vec,Vec);
+SLEPC_INTERN PetscErrorCode VecPointwiseMaxAbs_Comp(Vec,Vec,Vec);
+SLEPC_INTERN PetscErrorCode VecPointwiseMin_Comp(Vec,Vec,Vec);
+SLEPC_INTERN PetscErrorCode VecDotNorm2_Comp_Seq(Vec,Vec,PetscScalar*,PetscScalar*);
+SLEPC_INTERN PetscErrorCode VecDotNorm2_Comp_MPI(Vec,Vec,PetscScalar*,PetscScalar*);
+SLEPC_INTERN PetscErrorCode VecSqrtAbs_Comp(Vec);
+SLEPC_INTERN PetscErrorCode VecAbs_Comp(Vec);
+SLEPC_INTERN PetscErrorCode VecExp_Comp(Vec);
+SLEPC_INTERN PetscErrorCode VecLog_Comp(Vec);
+SLEPC_INTERN PetscErrorCode VecShift_Comp(Vec,PetscScalar);
+SLEPC_EXTERN PetscErrorCode VecCreate_Comp(Vec);
+
+/* VecPool */
+typedef struct VecPool_ {
+  Vec      v;              /* template vector */
+  Vec      *vecs;          /* pool of vectors */
+  PetscInt n;              /* size of vecs */
+  PetscInt used;           /* number of already used vectors */
+  PetscInt guess;          /* expected maximum number of vectors */
+  struct VecPool_ *next;   /* list of pool of vectors */
+} VecPool_;
+typedef VecPool_* VecPool;
+
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode SlepcVecPoolCreate(Vec,PetscInt,VecPool*);
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode SlepcVecPoolDestroy(VecPool*);
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode SlepcVecPoolGetVecs(VecPool,PetscInt,Vec**);
+SLEPC_SINGLE_LIBRARY_INTERN PetscErrorCode SlepcVecPoolRestoreVecs(VecPool,PetscInt,Vec**);

--- a/3rd/slepc/linux/include/slepcblaslapack.h
+++ b/3rd/slepc/linux/include/slepcblaslapack.h
@@ -1,0 +1,319 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   Necessary routines in BLAS and LAPACK not included in petscblaslapack.h
+*/
+
+#pragma once
+
+#include <petscblaslapack.h>
+
+/* Macro to check nonzero info after LAPACK call */
+#define SlepcCheckLapackInfo(routine,info) \
+  do { \
+    PetscCheck(!info,PETSC_COMM_SELF,PETSC_ERR_LIB,"Error in LAPACK subroutine %s: info=%" PetscBLASInt_FMT,routine,info); \
+  } while (0)
+
+/* LAPACK return type: we assume slange, etc. behave in the same way as snrm2 */
+#if defined(PETSC_USE_REAL_SINGLE) && defined(PETSC_BLASLAPACK_SNRM2_RETURNS_DOUBLE)
+#define SlepcLRT double
+#else
+#define SlepcLRT PetscReal
+#endif
+
+/* Special macro for srot, csrot, drot, zdrot (BLASMIXEDrot_) */
+#if !defined(PETSC_USE_COMPLEX)
+# define PETSC_BLASLAPACK_MIXEDPREFIX_ PETSC_BLASLAPACK_PREFIX_
+#else
+# if defined(PETSC_BLASLAPACK_CAPS)
+#  if defined(PETSC_USE_REAL_SINGLE)
+#   define PETSC_BLASLAPACK_MIXEDPREFIX_ CS
+#  elif defined(PETSC_USE_REAL_DOUBLE)
+#   define PETSC_BLASLAPACK_MIXEDPREFIX_ ZD
+#  elif defined(PETSC_USE_REAL___FLOAT128)
+#   define PETSC_BLASLAPACK_MIXEDPREFIX_ WQ
+#  else
+#   define PETSC_BLASLAPACK_MIXEDPREFIX_ KH
+#  endif
+# else
+#  if defined(PETSC_USE_REAL_SINGLE)
+#   define PETSC_BLASLAPACK_MIXEDPREFIX_ cs
+#  elif defined(PETSC_USE_REAL_DOUBLE)
+#   define PETSC_BLASLAPACK_MIXEDPREFIX_ zd
+#  elif defined(PETSC_USE_REAL___FLOAT128)
+#   define PETSC_BLASLAPACK_MIXEDPREFIX_ wq
+#  else
+#   define PETSC_BLASLAPACK_MIXEDPREFIX_ kh
+#  endif
+# endif
+#endif
+#if defined(PETSC_BLASLAPACK_CAPS)
+#  define PETSCBLASMIXED(x,X) PETSC_PASTE3(PETSC_BLASLAPACK_MIXEDPREFIX_, X, PETSC_BLASLAPACK_SUFFIX_)
+#else
+#  define PETSCBLASMIXED(x,X) PETSC_PASTE3(PETSC_BLASLAPACK_MIXEDPREFIX_, x, PETSC_BLASLAPACK_SUFFIX_)
+#endif
+
+#include <slepcblaslapack_mangle.h>
+
+/* LAPACK functions without string parameters */
+BLAS_EXTERN void     BLASrot_(PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscReal*,PetscScalar*);
+BLAS_EXTERN void     BLASMIXEDrot_(PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscReal*,PetscReal*);
+#if !defined(SLEPC_MISSING_LAPACK_LAEV2)
+BLAS_EXTERN void     LAPACKlaev2_(const PetscScalar*,const PetscScalar*,const PetscScalar*,PetscReal*,PetscReal*,PetscReal*,PetscScalar*);
+#else
+#define LAPACKlaev2_(a,b,c,d,e,f,g) PetscMissingLapack("LAEV2",a,b,c,d,e,f,g);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_GEHRD)
+BLAS_EXTERN void     LAPACKgehrd_(const PetscBLASInt*,const PetscBLASInt*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKgehrd_(a,b,c,d,e,f,g,h,i) PetscMissingLapack("GEHRD",a,b,c,d,e,f,g,h,i);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_GEBRD)
+BLAS_EXTERN void     LAPACKgebrd_(const PetscBLASInt*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscReal*,PetscScalar*,PetscScalar*,PetscScalar*,PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKgebrd_(a,b,c,d,e,f,g,h,i,j,k) PetscMissingLapack("GEBRD",a,b,c,d,e,f,g,h,i,j,k);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LARFG)
+BLAS_EXTERN void     LAPACKlarfg_(const PetscBLASInt*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscScalar*);
+#else
+#define LAPACKlarfg_(a,b,c,d,e) PetscMissingLapack("LARFG",a,b,c,d,e);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LAG2)
+BLAS_EXTERN void     LAPACKlag2_(const PetscReal*,const PetscBLASInt*,const PetscReal*,const PetscBLASInt*,const PetscReal*,PetscReal*,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
+#else
+#define LAPACKlag2_(a,b,c,d,e,f,g,h,i,j) PetscMissingLapack("LAG2",a,b,c,d,e,f,g,h,i,j);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LASV2)
+BLAS_EXTERN void     LAPACKlasv2_(const PetscReal*,const PetscReal*,const PetscReal*,PetscReal*,PetscReal*,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
+#else
+#define LAPACKlasv2_(a,b,c,d,e,f,g,h,i) PetscMissingLapack("LASV2",a,b,c,d,e,f,g,h,i);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LARTG)
+BLAS_EXTERN void     LAPACKlartg_(const PetscScalar*,const PetscScalar*,PetscReal*,PetscScalar*,PetscScalar*);
+BLAS_EXTERN void     LAPACKREALlartg_(const PetscReal*,const PetscReal*,PetscReal*,PetscReal*,PetscReal*);
+#else
+#define LAPACKlartg_(a,b,c,d,e) PetscMissingLapack("LARTG",a,b,c,d,e);
+#define LAPACKREALlartg_(a,b,c,d,e) PetscMissingLapack("LARTG",a,b,c,d,e);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LAED4)
+BLAS_EXTERN void     LAPACKlaed4_(const PetscBLASInt*,const PetscBLASInt*,const PetscReal*,const PetscReal*,PetscReal*,const PetscReal*,PetscReal*,PetscBLASInt*);
+#else
+#define LAPACKlaed4_(a,b,c,d,e,f,g,h) PetscMissingLapack("LAED4",a,b,c,d,e,f,g,h);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LAMRG)
+BLAS_EXTERN void     LAPACKlamrg_(const PetscBLASInt*,const PetscBLASInt*,const PetscReal*,const PetscBLASInt*,const PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKlamrg_(a,b,c,d,e,f) PetscMissingLapack("LAMRG",a,b,c,d,e,f);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_ORGHR)
+BLAS_EXTERN void     LAPACKorghr_(const PetscBLASInt*,const PetscBLASInt*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,const PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKorghr_(a,b,c,d,e,f,g,h,i) PetscMissingLapack("ORGHR",a,b,c,d,e,f,g,h,i);
+#endif
+#if !defined(PETSC_USE_COMPLEX)
+#if !defined(SLEPC_MISSING_LAPACK_TGEXC)
+BLAS_EXTERN void     LAPACKtgexc_(const PetscBLASInt*,const PetscBLASInt*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKtgexc_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p) PetscMissingLapack("TGEXC",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p);
+#endif
+BLAS_EXTERN void     LAPACKgeqp3_(const PetscBLASInt*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*);
+#else
+#if !defined(SLEPC_MISSING_LAPACK_TGEXC)
+BLAS_EXTERN void     LAPACKtgexc_(const PetscBLASInt*,const PetscBLASInt*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,const PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKtgexc_(a,b,c,d,e,f,g,h,i,j,k,l,m,n) PetscMissingLapack("TGEXC",a,b,c,d,e,f,g,h,i,j,k,l,m,n);
+#endif
+BLAS_EXTERN void     LAPACKgeqp3_(const PetscBLASInt*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscBLASInt*);
+#endif
+
+/* LAPACK functions with string parameters */
+
+/* same name for real and complex */
+BLAS_EXTERN void     BLAStrmm_(const char*,const char*,const char*,const char*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscBLASInt*);
+BLAS_EXTERN SlepcLRT LAPACKlange_(const char*,const PetscBLASInt*,const PetscBLASInt*,const PetscScalar*,const PetscBLASInt*,PetscReal*);
+#if !defined(SLEPC_MISSING_LAPACK_LANHS)
+BLAS_EXTERN SlepcLRT LAPACKlanhs_(const char*,const PetscBLASInt*,const PetscScalar*,const PetscBLASInt*,PetscReal*);
+#else
+static inline SlepcLRT LAPACKlanhs_(const char *norm,const PetscBLASInt *n,const PetscScalar *A,const PetscBLASInt *lda,PetscReal *work) {return LAPACKlange_(norm,n,n,A,lda,work);}
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LARF)
+BLAS_EXTERN void     LAPACKlarf_(const char*,const PetscBLASInt*,const PetscBLASInt*,const PetscScalar*,const PetscBLASInt*,const PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscScalar*);
+#else
+#define LAPACKlarf_(a,b,c,d,e,f,g,h,i) PetscMissingLapack("LARF",a,b,c,d,e,f,g,h,i);
+#endif
+BLAS_EXTERN SlepcLRT LAPACKlansy_(const char*,const char*,const PetscBLASInt*,const PetscScalar*,const PetscBLASInt*,PetscReal*);
+#if !defined(SLEPC_MISSING_LAPACK_TRSYL)
+BLAS_EXTERN void     LAPACKtrsyl_(const char*,const char*,const PetscBLASInt*,const PetscBLASInt*,const PetscBLASInt*,const PetscScalar*,const PetscBLASInt*,const PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscBLASInt*);
+#else
+#define LAPACKtrsyl_(a,b,c,d,e,f,g,h,i,j,k,l,m) PetscMissingLapack("TRSYL",a,b,c,d,e,f,g,h,i,j,k,l,m);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_BDSQR)
+BLAS_EXTERN void     LAPACKbdsqr_(const char*,const PetscBLASInt*,const PetscBLASInt*,const PetscBLASInt*,const PetscBLASInt*,PetscReal*,PetscReal*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscBLASInt*);
+#else
+#define LAPACKbdsqr_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) PetscMissingLapack("BDSQR",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o);
+#endif
+
+/* subroutines in which we use only the real version, do not care whether they have different name */
+#if !defined(SLEPC_MISSING_LAPACK_STEVR)
+BLAS_EXTERN void     LAPACKstevr_(const char*,const char*,PetscBLASInt*,PetscReal*,PetscReal*,PetscReal*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscReal*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKstevr_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t) PetscMissingLapack("STEVR",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_BDSDC)
+BLAS_EXTERN void     LAPACKbdsdc_(const char*,const char*,PetscBLASInt*,PetscReal*,PetscReal*,PetscReal*,PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKbdsdc_(a,b,c,d,e,f,g,h,i,j,k,l,m,n) PetscMissingLapack("BDSDC",a,b,c,d,e,f,g,h,i,j,k,l,m,n);
+#endif
+BLAS_EXTERN SlepcLRT LAPACKlamch_(const char*);
+BLAS_EXTERN SlepcLRT LAPACKlamc3_(PetscReal*,PetscReal*);
+
+/* subroutines with different name in real/complex */
+#if !defined(SLEPC_MISSING_LAPACK_ORGTR)
+BLAS_EXTERN void     LAPACKorgtr_(const char*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscScalar*,PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKorgtr_(a,b,c,d,e,f,g,h) PetscMissingLapack("ORGTR",a,b,c,d,e,f,g,h);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_ORMBR)
+BLAS_EXTERN void     LAPACKormbr_(const char*,const char*,const char*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKormbr_(a,b,c,d,e,f,g,h,i,j,k,l,m,n) PetscMissingLapack("ORMBR",a,b,c,d,e,f,g,h,i,j,k,l,m,n);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_SYTRD)
+BLAS_EXTERN void     LAPACKsytrd_(const char*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscReal*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKsytrd_(a,b,c,d,e,f,g,h,i,j) PetscMissingLapack("SYTRD",a,b,c,d,e,f,g,h,i,j);
+#endif
+#if !defined(PETSC_USE_COMPLEX)
+BLAS_EXTERN void     LAPACKsyevd_(const char*,const char*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*);
+BLAS_EXTERN void     LAPACKsygvd_(PetscBLASInt*,const char*,const char*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*);
+#else
+BLAS_EXTERN void     LAPACKsyevd_(const char*,const char*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscReal*,PetscScalar*,PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*);
+BLAS_EXTERN void     LAPACKsygvd_(PetscBLASInt*,const char*,const char*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscReal*,PetscScalar*,PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*);
+#endif
+
+/* subroutines with different signature in real/complex */
+#if !defined(PETSC_USE_COMPLEX)
+BLAS_EXTERN void     LAPACKggev_(const char*,const char*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,PetscScalar*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*);
+#if !defined(SLEPC_MISSING_LAPACK_GGEV3)
+BLAS_EXTERN void     LAPACKggev3_(const char*,const char*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,PetscScalar*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKggev3_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q) PetscMissingLapack("GGEV3",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_GGES3)
+BLAS_EXTERN void     LAPACKgges3_(const char*,const char*,const char*,PetscBLASInt(*)(void),const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscScalar*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKgges3_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u) PetscMissingLapack("GGES3",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_GGSVD)
+BLAS_EXTERN void     LAPACKggsvd_(const char*,const char*,const char*,const PetscBLASInt*,const PetscBLASInt*,const PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscReal*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKggsvd_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w) PetscMissingLapack("GGSVD",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_GGSVD3)
+BLAS_EXTERN void     LAPACKggsvd3_(const char*,const char*,const char*,const PetscBLASInt*,const PetscBLASInt*,const PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscReal*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKggsvd3_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x) PetscMissingLapack("GGSVD3",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_TREVC)
+BLAS_EXTERN void     LAPACKtrevc_(const char*,const char*,PetscBLASInt*,const PetscBLASInt*,const PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,const PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*);
+#else
+#define LAPACKtrevc_(a,b,c,d,e,f,g,h,i,j,k,l,m,n) PetscMissingLapack("TREVC",a,b,c,d,e,f,g,h,i,j,k,l,m,n);
+#endif
+BLAS_EXTERN void     LAPACKgeevx_(const char*,const char*,const char*,const char*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscScalar*,PetscScalar*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscBLASInt*);
+BLAS_EXTERN void     LAPACKgees_(const char*,const char*,PetscBLASInt(*)(PetscReal,PetscReal),const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscBLASInt*);
+#if !defined(SLEPC_MISSING_LAPACK_TREXC)
+BLAS_EXTERN void     LAPACKtrexc_(const char*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*);
+#else
+#define LAPACKtrexc_(a,b,c,d,e,f,g,h,i,j) PetscMissingLapack("TREXC",a,b,c,d,e,f,g,h,i,j);
+#endif
+BLAS_EXTERN void     LAPACKgesdd_(const char*,const PetscBLASInt*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscBLASInt*);
+#if !defined(SLEPC_MISSING_LAPACK_TGEVC)
+BLAS_EXTERN void     LAPACKtgevc_(const char*,const char*,const PetscBLASInt*,const PetscBLASInt*,const PetscScalar*,const PetscBLASInt*,const PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,const PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*);
+#else
+#define LAPACKtgevc_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p) PetscMissingLapack("TGEVC",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_HSEIN)
+BLAS_EXTERN void     LAPACKhsein_(const char*,const char*,const char*,PetscBLASInt*,const PetscBLASInt*,const PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,const PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKhsein_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s) PetscMissingLapack("HSEIN",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_STEDC)
+BLAS_EXTERN void     LAPACKstedc_(const char*,const PetscBLASInt*,PetscReal*,PetscReal*,PetscScalar*,const PetscBLASInt*,PetscReal*,const PetscBLASInt*,PetscBLASInt*,const PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKstedc_(a,b,c,d,e,f,g,h,i,j,k) PetscMissingLapack("STEDC",a,b,c,d,e,f,g,h,i,j,k);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LASCL)
+BLAS_EXTERN void     LAPACKlascl_(const char*,const PetscBLASInt*,const PetscBLASInt*,const PetscScalar*,const PetscScalar*,const PetscBLASInt*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKlascl_(a,b,c,d,e,f,g,h,i,j) PetscMissingLapack("LASCL",a,b,c,d,e,f,g,h,i,j);
+#endif
+#else
+BLAS_EXTERN void     LAPACKggev_(const char*,const char*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscBLASInt*);
+#if !defined(SLEPC_MISSING_LAPACK_GGEV3)
+BLAS_EXTERN void     LAPACKggev3_(const char*,const char*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscBLASInt*);
+#else
+#define LAPACKggev3_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q) PetscMissingLapack("GGEV3",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_GGES3)
+BLAS_EXTERN void     LAPACKgges3_(const char*,const char*,const char*,PetscBLASInt(*)(void),const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKgges3_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u) PetscMissingLapack("GGES3",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_GGSVD)
+BLAS_EXTERN void     LAPACKggsvd_(const char*,const char*,const char*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscReal*,PetscReal*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscScalar*,PetscReal*,PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKggsvd_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x) PetscMissingLapack("GGSVD",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_GGSVD3)
+BLAS_EXTERN void     LAPACKggsvd3_(const char*,const char*,const char*,const PetscBLASInt*,const PetscBLASInt*,const PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscReal*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKggsvd3_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y) PetscMissingLapack("GGSVD3",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_TREVC)
+BLAS_EXTERN void     LAPACKtrevc_(const char*,const char*,const PetscBLASInt*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,const PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscReal*,PetscBLASInt*);
+#else
+#define LAPACKtrevc_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) PetscMissingLapack("TREVC",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o);
+#endif
+BLAS_EXTERN void     LAPACKgeevx_(const char*,const char*,const char*,const char*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscBLASInt*,PetscReal*,PetscReal*,PetscReal*,PetscReal*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscBLASInt*);
+BLAS_EXTERN void     LAPACKgees_(const char*,const char*,PetscBLASInt(*)(PetscScalar),const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscBLASInt*);
+#if !defined(SLEPC_MISSING_LAPACK_TREXC)
+BLAS_EXTERN void     LAPACKtrexc_(const char*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,const PetscBLASInt*,const PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKtrexc_(a,b,c,d,e,f,g,h,i) PetscMissingLapack("TREXC",a,b,c,d,e,f,g,h,i);
+#endif
+BLAS_EXTERN void     LAPACKgesdd_(const char*,const PetscBLASInt*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,PetscBLASInt*,PetscBLASInt*);
+#if !defined(SLEPC_MISSING_LAPACK_TGEVC)
+BLAS_EXTERN void     LAPACKtgevc_(const char*,const char*,const PetscBLASInt*,const PetscBLASInt*,const PetscScalar*,const PetscBLASInt*,const PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,const PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscReal*,PetscBLASInt*);
+#else
+#define LAPACKtgevc_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q) PetscMissingLapack("TGEVC",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_HSEIN)
+BLAS_EXTERN void     LAPACKhsein_(const char*,const char*,const char*,const PetscBLASInt*,const PetscBLASInt*,const PetscScalar*,const PetscBLASInt*,PetscScalar*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,const PetscBLASInt*,PetscBLASInt*,PetscScalar*,PetscReal*,PetscBLASInt*,PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKhsein_(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s) PetscMissingLapack("HSEIN",a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_STEDC)
+BLAS_EXTERN void     LAPACKstedc_(const char*,const PetscBLASInt*,PetscReal*,PetscReal*,PetscScalar*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscReal*,const PetscBLASInt*,PetscBLASInt*,const PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKstedc_(a,b,c,d,e,f,g,h,i,j,k,l,m) PetscMissingLapack("STEDC",a,b,c,d,e,f,g,h,i,j,k,l,m);
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LASCL)
+BLAS_EXTERN void     LAPACKlascl_(const char*,const PetscBLASInt*,const PetscBLASInt*,const PetscReal*,const PetscReal*,const PetscBLASInt*,const PetscBLASInt*,PetscScalar*,const PetscBLASInt*,PetscBLASInt*);
+#else
+#define LAPACKlascl_(a,b,c,d,e,f,g,h,i,j) PetscMissingLapack("LASCL",a,b,c,d,e,f,g,h,i,j);
+#endif
+#endif
+
+#if defined(PETSC_HAVE_COMPLEX)
+/* complex subroutines to be called with scalar-type=real */
+BLAS_EXTERN void BLASCOMPLEXgemm_(const char*,const char*,const PetscBLASInt*,const PetscBLASInt*,const PetscBLASInt*,const PetscComplex*,const PetscComplex*,const PetscBLASInt*,const PetscComplex*,const PetscBLASInt*,const PetscComplex*,PetscComplex*,const PetscBLASInt*);
+BLAS_EXTERN void BLASCOMPLEXscal_(const PetscBLASInt*,const PetscComplex*,PetscComplex*,const PetscBLASInt*);
+BLAS_EXTERN void LAPACKCOMPLEXgesv_(const PetscBLASInt*,const PetscBLASInt*,PetscComplex*,const PetscBLASInt*,PetscBLASInt*,PetscComplex*,const PetscBLASInt*,PetscBLASInt*);
+#endif

--- a/3rd/slepc/linux/include/slepcblaslapack_mangle.h
+++ b/3rd/slepc/linux/include/slepcblaslapack_mangle.h
@@ -1,0 +1,159 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+/* LAPACK functions without string parameters */
+#define BLASrot_     PETSCBLAS(rot,ROT)
+#define BLASMIXEDrot_ PETSCBLASMIXED(rot,ROT)
+#if !defined(SLEPC_MISSING_LAPACK_LAEV2)
+#define LAPACKlaev2_ PETSCBLAS(laev2,LAEV2)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_GEHRD)
+#define LAPACKgehrd_ PETSCBLAS(gehrd,GEHRD)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LARFG)
+#define LAPACKlarfg_ PETSCBLAS(larfg,LARFG)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LAG2)
+#define LAPACKlag2_  PETSCBLASREAL(lag2,LAG2)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LASV2)
+#define LAPACKlasv2_ PETSCBLASREAL(lasv2,LASV2)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LARTG)
+#define LAPACKlartg_ PETSCBLAS(lartg,LARTG)
+#define LAPACKREALlartg_ PETSCBLASREAL(lartg,LARTG)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LAED4)
+#define LAPACKlaed4_ PETSCBLASREAL(laed4,LAED4)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LAMRG)
+#define LAPACKlamrg_ PETSCBLASREAL(lamrg,LAMRG)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_ORGHR)
+#if !defined(PETSC_USE_COMPLEX)
+#define LAPACKorghr_ PETSCBLAS(orghr,ORGHR)
+#else
+#define LAPACKorghr_ PETSCBLAS(unghr,UNGHR)
+#endif
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_TGEXC)
+#define LAPACKtgexc_ PETSCBLAS(tgexc,TGEXC)
+#endif
+#define LAPACKgeqp3_ PETSCBLAS(geqp3,GEQP3)
+
+/* LAPACK functions with string parameters */
+
+/* same name for real and complex */
+#define BLAStrmm_    PETSCBLAS(trmm,TRMM)
+#if !defined(SLEPC_MISSING_LAPACK_LANHS)
+#define LAPACKlanhs_ PETSCBLAS(lanhs,LANHS)
+#endif
+#define LAPACKlange_ PETSCBLAS(lange,LANGE)
+#if !defined(SLEPC_MISSING_LAPACK_LARF)
+#define LAPACKlarf_  PETSCBLAS(larf,LARF)
+#endif
+#define LAPACKlansy_ PETSCBLAS(lansy,LANSY)
+#if !defined(SLEPC_MISSING_LAPACK_TRSYL)
+#define LAPACKtrsyl_ PETSCBLAS(trsyl,TRSYL)
+#endif
+
+/* subroutines in which we use only the real version, do not care whether they have different name */
+#if !defined(SLEPC_MISSING_LAPACK_STEVR)
+#define LAPACKstevr_ PETSCBLASREAL(stevr,STEVR)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_BDSDC)
+#define LAPACKbdsdc_ PETSCBLASREAL(bdsdc,BDSDC)
+#endif
+#define LAPACKlamch_ PETSCBLASREAL(lamch,LAMCH)
+#define LAPACKlamc3_ PETSCBLASREAL(lamc3,LAMC3)
+
+/* subroutines with different name in real/complex */
+#if !defined(PETSC_USE_COMPLEX)
+#if !defined(SLEPC_MISSING_LAPACK_ORGTR)
+#define LAPACKorgtr_ PETSCBLAS(orgtr,ORGTR)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_ORMBR)
+#define LAPACKormbr_ PETSCBLAS(ormbr,ORMBR)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_SYTRD)
+#define LAPACKsytrd_ PETSCBLAS(sytrd,SYTRD)
+#endif
+#define LAPACKsyevd_ PETSCBLAS(syevd,SYEVD)
+#define LAPACKsygvd_ PETSCBLAS(sygvd,SYGVD)
+#else
+#if !defined(SLEPC_MISSING_LAPACK_ORGTR)
+#define LAPACKorgtr_ PETSCBLAS(ungtr,UNGTR)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_ORMBR)
+#define LAPACKormbr_ PETSCBLAS(unmbr,UNMBR)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_SYTRD)
+#define LAPACKsytrd_ PETSCBLAS(hetrd,HETRD)
+#endif
+#define LAPACKsyevd_ PETSCBLAS(heevd,HEEVD)
+#define LAPACKsygvd_ PETSCBLAS(hegvd,HEGVD)
+#endif
+
+/* subroutines with different signature in real/complex */
+#define LAPACKggev_  PETSCBLAS(ggev,GGEV)
+#if !defined(SLEPC_MISSING_LAPACK_GGEV3)   /* ggev and ggev3 have the same signature */
+#define LAPACKggev3_ PETSCBLAS(ggev3,GGEV3)
+#define LAPACKggevalt_ LAPACKggev3_
+#else
+#define LAPACKggevalt_ LAPACKggev_
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_GGES3)   /* gges and gges3 have the same signature */
+#define LAPACKgges3_ PETSCBLAS(gges3,GGES3)
+#define LAPACKggesalt_ LAPACKgges3_
+#else
+#define LAPACKggesalt_ LAPACKgges_
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_GGSVD)
+#define LAPACKggsvd_ PETSCBLAS(ggsvd,GGSVD)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_GGSVD3)
+#define LAPACKggsvd3_ PETSCBLAS(ggsvd3,GGSVD3)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_TREVC)
+#define LAPACKtrevc_ PETSCBLAS(trevc,TREVC)
+#endif
+#define LAPACKgeevx_ PETSCBLAS(geevx,GEEVX)
+#define LAPACKgees_  PETSCBLAS(gees,GEES)
+#if !defined(SLEPC_MISSING_LAPACK_TREXC)
+#define LAPACKtrexc_ PETSCBLAS(trexc,TREXC)
+#endif
+#define LAPACKgesdd_ PETSCBLAS(gesdd,GESDD)
+#if !defined(SLEPC_MISSING_LAPACK_TGEVC)
+#define LAPACKtgevc_ PETSCBLAS(tgevc,TGEVC)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_HSEIN)
+#define LAPACKhsein_ PETSCBLAS(hsein,HSEIN)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_STEDC)
+#define LAPACKstedc_ PETSCBLAS(stedc,STEDC)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_LASCL)
+#define LAPACKlascl_ PETSCBLAS(lascl,LASCL)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_BDSQR)
+#define LAPACKbdsqr_ PETSCBLAS(bdsqr,BDSQR)
+#endif
+#if !defined(SLEPC_MISSING_LAPACK_GEBRD)
+#define LAPACKgebrd_ PETSCBLAS(gebrd,GEBRD)
+#endif
+
+#if defined(PETSC_HAVE_COMPLEX)
+/* complex subroutines to be called with scalar-type=real */
+#define BLASCOMPLEXgemm_   PETSCBLASCOMPLEX(gemm,GEMM)
+#define BLASCOMPLEXscal_   PETSCBLASCOMPLEX(scal,SCAL)
+#define LAPACKCOMPLEXgesv_ PETSCBLASCOMPLEX(gesv,GESV)
+#endif

--- a/3rd/slepc/linux/include/slepcbv.h
+++ b/3rd/slepc/linux/include/slepcbv.h
@@ -1,0 +1,259 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   User interface for the basis vectors object in SLEPc
+*/
+
+#pragma once
+
+#include <slepcsys.h>
+
+/* SUBMANSEC = BV */
+
+SLEPC_EXTERN PetscErrorCode BVInitializePackage(void);
+SLEPC_EXTERN PetscErrorCode BVFinalizePackage(void);
+
+/*S
+    BV - Basis vectors, SLEPc object representing a collection of vectors
+    that typically constitute a basis of a subspace.
+
+    Level: beginner
+
+.seealso:  BVCreate()
+S*/
+typedef struct _p_BV* BV;
+
+/*J
+    BVType - String with the name of the type of BV. Each type differs in
+    the way data is stored internally.
+
+    Level: beginner
+
+.seealso: BVSetType(), BV
+J*/
+typedef const char* BVType;
+#define BVMAT        "mat"
+#define BVSVEC       "svec"
+#define BVVECS       "vecs"
+#define BVCONTIGUOUS "contiguous"
+#define BVTENSOR     "tensor"
+
+/* Logging support */
+SLEPC_EXTERN PetscClassId BV_CLASSID;
+
+/*E
+    BVOrthogType - Determines the method used in the orthogonalization
+    of vectors
+
+    Level: advanced
+
+.seealso: BVSetOrthogonalization(), BVGetOrthogonalization(), BVOrthogonalizeColumn(), BVOrthogRefineType
+E*/
+typedef enum { BV_ORTHOG_CGS,
+               BV_ORTHOG_MGS } BVOrthogType;
+SLEPC_EXTERN const char *BVOrthogTypes[];
+
+/*E
+    BVOrthogRefineType - Determines what type of refinement to use
+    during orthogonalization of vectors
+
+    Level: advanced
+
+.seealso: BVSetOrthogonalization(), BVGetOrthogonalization(), BVOrthogonalizeColumn()
+E*/
+typedef enum { BV_ORTHOG_REFINE_IFNEEDED,
+               BV_ORTHOG_REFINE_NEVER,
+               BV_ORTHOG_REFINE_ALWAYS } BVOrthogRefineType;
+SLEPC_EXTERN const char *BVOrthogRefineTypes[];
+
+/*E
+    BVOrthogBlockType - Determines the method used in block
+    orthogonalization (simultaneous orthogonalization of a set of vectors)
+
+    Level: advanced
+
+.seealso: BVSetOrthogonalization(), BVGetOrthogonalization(), BVOrthogonalize()
+E*/
+typedef enum { BV_ORTHOG_BLOCK_GS,
+               BV_ORTHOG_BLOCK_CHOL,
+               BV_ORTHOG_BLOCK_TSQR,
+               BV_ORTHOG_BLOCK_TSQRCHOL,
+               BV_ORTHOG_BLOCK_SVQB     } BVOrthogBlockType;
+SLEPC_EXTERN const char *BVOrthogBlockTypes[];
+
+/*E
+   BVMatMultType - Different ways of performing the BVMatMult() operation
+
+   Notes:
+   Allowed values are
++  BV_MATMULT_VECS - perform a matrix-vector multiply per each column
+.  BV_MATMULT_MAT - carry out a Mat-Mat product with a dense matrix
+-  BV_MATMULT_MAT_SAVE - this case is deprecated
+
+   The default is BV_MATMULT_MAT except in the case of BVVECS.
+
+   Level: advanced
+
+.seealso: BVSetMatMultMethod(), BVMatMult()
+E*/
+typedef enum { BV_MATMULT_VECS,
+               BV_MATMULT_MAT,
+               BV_MATMULT_MAT_SAVE } BVMatMultType;
+SLEPC_EXTERN const char *BVMatMultTypes[];
+
+SLEPC_EXTERN PetscErrorCode BVCreate(MPI_Comm,BV*);
+SLEPC_EXTERN PetscErrorCode BVDestroy(BV*);
+SLEPC_EXTERN PetscErrorCode BVSetType(BV,BVType);
+SLEPC_EXTERN PetscErrorCode BVGetType(BV,BVType*);
+SLEPC_EXTERN PetscErrorCode BVSetSizes(BV,PetscInt,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode BVSetSizesFromVec(BV,Vec,PetscInt);
+SLEPC_EXTERN PetscErrorCode BVSetLeadingDimension(BV,PetscInt);
+SLEPC_EXTERN PetscErrorCode BVGetLeadingDimension(BV,PetscInt*);
+SLEPC_EXTERN PetscErrorCode BVGetSizes(BV,PetscInt*,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode BVResize(BV,PetscInt,PetscBool);
+SLEPC_EXTERN PetscErrorCode BVSetFromOptions(BV);
+SLEPC_EXTERN PetscErrorCode BVView(BV,PetscViewer);
+SLEPC_EXTERN PetscErrorCode BVViewFromOptions(BV,PetscObject,const char[]);
+
+SLEPC_EXTERN PetscErrorCode BVGetColumn(BV,PetscInt,Vec*);
+SLEPC_EXTERN PetscErrorCode BVRestoreColumn(BV,PetscInt,Vec*);
+SLEPC_EXTERN PetscErrorCode BVGetSplit(BV,BV*,BV*);
+SLEPC_EXTERN PetscErrorCode BVRestoreSplit(BV,BV*,BV*);
+SLEPC_EXTERN PetscErrorCode BVGetSplitRows(BV,IS,IS,BV*,BV*);
+SLEPC_EXTERN PetscErrorCode BVRestoreSplitRows(BV,IS,IS,BV*,BV*);
+SLEPC_EXTERN PetscErrorCode BVGetArray(BV,PetscScalar**);
+SLEPC_EXTERN PetscErrorCode BVRestoreArray(BV,PetscScalar**);
+SLEPC_EXTERN PetscErrorCode BVGetArrayRead(BV,const PetscScalar**);
+SLEPC_EXTERN PetscErrorCode BVRestoreArrayRead(BV,const PetscScalar**);
+SLEPC_EXTERN PetscErrorCode BVCreateVec(BV,Vec*);
+SLEPC_EXTERN PetscErrorCode BVCreateVecEmpty(BV,Vec*);
+SLEPC_EXTERN PetscErrorCode BVSetVecType(BV,VecType);
+SLEPC_EXTERN PetscErrorCode BVGetVecType(BV,VecType*);
+SLEPC_EXTERN PetscErrorCode BVSetActiveColumns(BV,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode BVGetActiveColumns(BV,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode BVInsertVec(BV,PetscInt,Vec);
+SLEPC_EXTERN PetscErrorCode BVInsertVecs(BV,PetscInt,PetscInt*,Vec*,PetscBool);
+SLEPC_EXTERN PetscErrorCode BVInsertConstraints(BV,PetscInt*,Vec*);
+SLEPC_EXTERN PetscErrorCode BVSetNumConstraints(BV,PetscInt);
+SLEPC_EXTERN PetscErrorCode BVGetNumConstraints(BV,PetscInt*);
+SLEPC_EXTERN PetscErrorCode BVSetDefiniteTolerance(BV,PetscReal);
+SLEPC_EXTERN PetscErrorCode BVGetDefiniteTolerance(BV,PetscReal*);
+SLEPC_EXTERN PetscErrorCode BVDuplicate(BV,BV*);
+SLEPC_EXTERN PetscErrorCode BVDuplicateResize(BV,PetscInt,BV*);
+SLEPC_EXTERN PetscErrorCode BVCopy(BV,BV);
+SLEPC_EXTERN PetscErrorCode BVCopyVec(BV,PetscInt,Vec);
+SLEPC_EXTERN PetscErrorCode BVCopyColumn(BV,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode BVSetMatrix(BV,Mat,PetscBool);
+SLEPC_EXTERN PetscErrorCode BVGetMatrix(BV,Mat*,PetscBool*);
+SLEPC_EXTERN PetscErrorCode BVApplyMatrix(BV,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode BVApplyMatrixBV(BV,BV);
+SLEPC_EXTERN PetscErrorCode BVGetCachedBV(BV,BV*);
+SLEPC_EXTERN PetscErrorCode BVSetSignature(BV,Vec);
+SLEPC_EXTERN PetscErrorCode BVGetSignature(BV,Vec);
+SLEPC_EXTERN PetscErrorCode BVSetBufferVec(BV,Vec);
+SLEPC_EXTERN PetscErrorCode BVGetBufferVec(BV,Vec*);
+
+SLEPC_EXTERN PetscErrorCode BVMult(BV,PetscScalar,PetscScalar,BV,Mat);
+SLEPC_EXTERN PetscErrorCode BVMultVec(BV,PetscScalar,PetscScalar,Vec,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode BVMultColumn(BV,PetscScalar,PetscScalar,PetscInt,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode BVMultInPlace(BV,Mat,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode BVMultInPlaceHermitianTranspose(BV,Mat,PetscInt,PetscInt);
+PETSC_DEPRECATED_FUNCTION(3, 16, 0, "BVMultInPlaceHermitianTranspose()", ) static inline PetscErrorCode BVMultInPlaceTranspose(BV bv,Mat A,PetscInt s,PetscInt e) {return BVMultInPlaceHermitianTranspose(bv,A,s,e);}
+SLEPC_EXTERN PetscErrorCode BVMatMult(BV,Mat,BV);
+SLEPC_EXTERN PetscErrorCode BVMatMultTranspose(BV,Mat,BV);
+SLEPC_EXTERN PetscErrorCode BVMatMultHermitianTranspose(BV,Mat,BV);
+SLEPC_EXTERN PetscErrorCode BVMatMultColumn(BV,Mat,PetscInt);
+SLEPC_EXTERN PetscErrorCode BVMatMultTransposeColumn(BV,Mat,PetscInt);
+SLEPC_EXTERN PetscErrorCode BVMatMultHermitianTransposeColumn(BV,Mat,PetscInt);
+SLEPC_EXTERN PetscErrorCode BVMatProject(BV,Mat,BV,Mat);
+SLEPC_EXTERN PetscErrorCode BVMatArnoldi(BV,Mat,Mat,PetscInt,PetscInt*,PetscReal*,PetscBool*);
+SLEPC_EXTERN PetscErrorCode BVMatLanczos(BV,Mat,Mat,PetscInt,PetscInt*,PetscReal*,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode BVDot(BV,BV,Mat);
+SLEPC_EXTERN PetscErrorCode BVDotVec(BV,Vec,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode BVDotVecBegin(BV,Vec,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode BVDotVecEnd(BV,Vec,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode BVDotColumn(BV,PetscInt,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode BVDotColumnBegin(BV,PetscInt,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode BVDotColumnEnd(BV,PetscInt,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode BVScale(BV,PetscScalar);
+SLEPC_EXTERN PetscErrorCode BVScaleColumn(BV,PetscInt,PetscScalar);
+SLEPC_EXTERN PetscErrorCode BVNorm(BV,NormType,PetscReal*);
+SLEPC_EXTERN PetscErrorCode BVNormVec(BV,Vec,NormType,PetscReal*);
+SLEPC_EXTERN PetscErrorCode BVNormVecBegin(BV,Vec,NormType,PetscReal*);
+SLEPC_EXTERN PetscErrorCode BVNormVecEnd(BV,Vec,NormType,PetscReal*);
+SLEPC_EXTERN PetscErrorCode BVNormColumn(BV,PetscInt,NormType,PetscReal*);
+SLEPC_EXTERN PetscErrorCode BVNormColumnBegin(BV,PetscInt,NormType,PetscReal*);
+SLEPC_EXTERN PetscErrorCode BVNormColumnEnd(BV,PetscInt,NormType,PetscReal*);
+SLEPC_EXTERN PetscErrorCode BVNormalize(BV,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode BVSetRandom(BV);
+SLEPC_EXTERN PetscErrorCode BVSetRandomNormal(BV);
+SLEPC_EXTERN PetscErrorCode BVSetRandomSign(BV);
+SLEPC_EXTERN PetscErrorCode BVSetRandomColumn(BV,PetscInt);
+SLEPC_EXTERN PetscErrorCode BVSetRandomCond(BV,PetscReal);
+SLEPC_EXTERN PetscErrorCode BVSetRandomContext(BV,PetscRandom);
+SLEPC_EXTERN PetscErrorCode BVGetRandomContext(BV,PetscRandom*);
+
+SLEPC_EXTERN PetscErrorCode BVSetOrthogonalization(BV,BVOrthogType,BVOrthogRefineType,PetscReal,BVOrthogBlockType);
+SLEPC_EXTERN PetscErrorCode BVGetOrthogonalization(BV,BVOrthogType*,BVOrthogRefineType*,PetscReal*,BVOrthogBlockType*);
+SLEPC_EXTERN PetscErrorCode BVOrthogonalize(BV,Mat);
+SLEPC_EXTERN PetscErrorCode BVOrthogonalizeVec(BV,Vec,PetscScalar*,PetscReal*,PetscBool*);
+SLEPC_EXTERN PetscErrorCode BVOrthogonalizeColumn(BV,PetscInt,PetscScalar*,PetscReal*,PetscBool*);
+SLEPC_EXTERN PetscErrorCode BVOrthonormalizeColumn(BV,PetscInt,PetscBool,PetscReal*,PetscBool*);
+SLEPC_EXTERN PetscErrorCode BVOrthogonalizeSomeColumn(BV,PetscInt,PetscBool*,PetscScalar*,PetscReal*,PetscBool*);
+SLEPC_EXTERN PetscErrorCode BVBiorthogonalizeColumn(BV,BV,PetscInt);
+SLEPC_EXTERN PetscErrorCode BVBiorthonormalizeColumn(BV,BV,PetscInt,PetscReal*);
+SLEPC_EXTERN PetscErrorCode BVSetMatMultMethod(BV,BVMatMultType);
+SLEPC_EXTERN PetscErrorCode BVGetMatMultMethod(BV,BVMatMultType*);
+
+SLEPC_EXTERN PetscErrorCode BVCreateFromMat(Mat,BV*);
+SLEPC_EXTERN PetscErrorCode BVCreateMat(BV,Mat*);
+SLEPC_EXTERN PetscErrorCode BVGetMat(BV,Mat*);
+SLEPC_EXTERN PetscErrorCode BVRestoreMat(BV,Mat*);
+
+SLEPC_EXTERN PetscErrorCode BVScatter(BV,BV,VecScatter,Vec);
+SLEPC_EXTERN PetscErrorCode BVSumQuadrature(BV,BV,PetscInt,PetscInt,PetscInt,PetscScalar*,PetscScalar*,VecScatter,PetscSubcomm,PetscInt,PetscBool);
+SLEPC_EXTERN PetscErrorCode BVDotQuadrature(BV,BV,PetscScalar*,PetscInt,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscSubcomm,PetscInt,PetscBool);
+SLEPC_EXTERN PetscErrorCode BVTraceQuadrature(BV,BV,PetscInt,PetscInt,PetscScalar*,VecScatter,PetscSubcomm,PetscInt,PetscBool,PetscReal*);
+
+/*E
+   BVSVDMethod - Different methods for computing the SVD of a BV
+
+   Notes:
+   Allowed values are
++  BV_SVD_METHOD_REFINE - based on the SVD of the cross product matrix S'*S, with refinement
+.  BV_SVD_METHOD_QR     - based on the SVD of the triangular factor of qr(S)
+-  BV_SVD_METHOD_QR_CAA - variant of QR intended for use in cammunication-avoiding Arnoldi
+
+   Level: developer
+
+.seealso: BVSVDAndRank()
+E*/
+typedef enum { BV_SVD_METHOD_REFINE,
+               BV_SVD_METHOD_QR,
+               BV_SVD_METHOD_QR_CAA } BVSVDMethod;
+SLEPC_EXTERN const char *BVSVDMethods[];
+
+SLEPC_EXTERN PetscErrorCode BVSVDAndRank(BV,PetscInt,PetscInt,PetscReal,BVSVDMethod,PetscScalar*,PetscReal*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode BVCISSResizeBases(BV,BV,BV,PetscInt,PetscInt,PetscInt,PetscInt);
+
+SLEPC_EXTERN PetscErrorCode BVCreateTensor(BV,PetscInt,BV*);
+SLEPC_EXTERN PetscErrorCode BVTensorBuildFirstColumn(BV,PetscInt);
+SLEPC_EXTERN PetscErrorCode BVTensorCompress(BV,PetscInt);
+SLEPC_EXTERN PetscErrorCode BVTensorGetDegree(BV,PetscInt*);
+SLEPC_EXTERN PetscErrorCode BVTensorGetFactors(BV,BV*,Mat*);
+SLEPC_EXTERN PetscErrorCode BVTensorRestoreFactors(BV,BV*,Mat*);
+
+SLEPC_EXTERN PetscErrorCode BVSetOptionsPrefix(BV,const char*);
+SLEPC_EXTERN PetscErrorCode BVAppendOptionsPrefix(BV,const char*);
+SLEPC_EXTERN PetscErrorCode BVGetOptionsPrefix(BV,const char*[]);
+
+SLEPC_EXTERN PetscFunctionList BVList;
+SLEPC_EXTERN PetscErrorCode BVRegister(const char[],PetscErrorCode(*)(BV));

--- a/3rd/slepc/linux/include/slepcconf.h
+++ b/3rd/slepc/linux/include/slepcconf.h
@@ -1,0 +1,12 @@
+#if !defined(INCLUDED_SLEPCCONF_H)
+#define INCLUDED_SLEPCCONF_H
+
+#define SLEPC_PETSC_DIR "/home/ma/myCode/petsc-3.22.3"
+#define SLEPC_PETSC_ARCH "petsc_arch"
+#define SLEPC_DIR "/home/ma/myCode/slepc-3.22.2"
+#define SLEPC_LIB_DIR "/home/ma/myCode/slepc-3.22.2/petsc_arch/lib"
+#define SLEPC_MISSING_LAPACK_GGSVD3 1
+#define SLEPC_MISSING_LAPACK_GGEV3 1
+#define SLEPC_MISSING_LAPACK_GGES3 1
+#define SLEPC_HAVE_PACKAGES ":"
+#endif

--- a/3rd/slepc/linux/include/slepccupmblas.h
+++ b/3rd/slepc/linux/include/slepccupmblas.h
@@ -1,0 +1,66 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   Macro definitions to use cuBLAS and hipBLAS functionality
+*/
+
+#pragma once
+
+#include <petscdevice.h>
+#include <petsc/private/petsclegacycupmblas.h>
+
+#if defined(PETSC_HAVE_CUDA)
+
+/* complex single */
+#if defined(PETSC_USE_COMPLEX)
+#if defined(PETSC_USE_REAL_SINGLE)
+#define cublasXgetrfBatched(a,b,c,d,e,f,g) cublasCgetrfBatched((a),(b),(cuComplex**)(c),(d),(e),(f),(g))
+#define cublasXgetrsBatched(a,b,c,d,e,f,g,h,i,j,k) cublasCgetrsBatched((a),(b),(c),(d),(const cuComplex**)(e),(f),(g),(cuComplex**)(h),(i),(j),(k))
+#else /* complex double */
+#define cublasXgetrfBatched(a,b,c,d,e,f,g) cublasZgetrfBatched((a),(b),(cuDoubleComplex**)(c),(d),(e),(f),(g))
+#define cublasXgetrsBatched(a,b,c,d,e,f,g,h,i,j,k) cublasZgetrsBatched((a),(b),(c),(d),(const cuDoubleComplex**)(e),(f),(g),(cuDoubleComplex**)(h),(i),(j),(k))
+#endif
+#else /* real single */
+#if defined(PETSC_USE_REAL_SINGLE)
+#define cublasXgetrfBatched cublasSgetrfBatched
+#define cublasXgetrsBatched cublasSgetrsBatched
+#else /* real double */
+#define cublasXgetrfBatched cublasDgetrfBatched
+#define cublasXgetrsBatched cublasDgetrsBatched
+#endif
+#endif
+
+/* the following ones are used for PetscComplex in both real and complex scalars */
+#if defined(PETSC_USE_REAL_SINGLE)
+#define cublasXCaxpy(a,b,c,d,e,f,g)                cublasCaxpy((a),(b),(const cuComplex *)(c),(const cuComplex *)(d),(e),(cuComplex *)(f),(g))
+#define cublasXCgemm(a,b,c,d,e,f,g,h,i,j,k,l,m,n)  cublasCgemm((a),(b),(c),(d),(e),(f),(const cuComplex *)(g),(const cuComplex *)(h),(i),(const cuComplex *)(j),(k),(const cuComplex *)(l),(cuComplex *)(m),(n))
+#define cublasXCscal(a,b,c,d,e)                    cublasCscal((a),(b),(const cuComplex *)(c),(cuComplex *)(d),(e))
+#else
+#define cublasXCaxpy(a,b,c,d,e,f,g)                cublasZaxpy((a),(b),(const cuDoubleComplex *)(c),(const cuDoubleComplex *)(d),(e),(cuDoubleComplex *)(f),(g))
+#define cublasXCgemm(a,b,c,d,e,f,g,h,i,j,k,l,m,n)  cublasZgemm((a),(b),(c),(d),(e),(f),(const cuDoubleComplex *)(g),(const cuDoubleComplex *)(h),(i),(const cuDoubleComplex *)(j),(k),(const cuDoubleComplex *)(l),(cuDoubleComplex *)(m),(n))
+#define cublasXCscal(a,b,c,d,e)                    cublasZscal((a),(b),(const cuDoubleComplex *)(c),(cuDoubleComplex *)(d),(e))
+#endif
+
+#endif // PETSC_HAVE_CUDA
+
+#if defined(PETSC_HAVE_HIP)
+
+/* complex single */
+#if defined(PETSC_USE_COMPLEX)
+#if defined(PETSC_USE_REAL_SINGLE)
+#else /* complex double */
+#endif
+#else /* real single */
+#if defined(PETSC_USE_REAL_SINGLE)
+#else /* real double */
+#endif
+#endif
+
+#endif // PETSC_HAVE_HIP

--- a/3rd/slepc/linux/include/slepcds.h
+++ b/3rd/slepc/linux/include/slepcds.h
@@ -1,0 +1,272 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   User interface for the direct solver object in SLEPc
+*/
+
+#pragma once
+
+#include <slepcsc.h>
+#include <slepcfn.h>
+#include <slepcrg.h>
+
+/* SUBMANSEC = DS */
+
+#define DS_MAX_SOLVE 6
+
+SLEPC_EXTERN PetscErrorCode DSInitializePackage(void);
+SLEPC_EXTERN PetscErrorCode DSFinalizePackage(void);
+
+/*S
+    DS - Direct solver (or dense system), to represent low-dimensional
+    eigenproblems that must be solved within iterative solvers. This is an
+    auxiliary object and is not normally needed by application programmers.
+
+    Level: beginner
+
+.seealso:  DSCreate()
+S*/
+typedef struct _p_DS* DS;
+
+/*J
+    DSType - String with the name of the type of direct solver. Roughly,
+    there are as many types as problem types are available within SLEPc.
+
+    Level: advanced
+
+.seealso: DSSetType(), DS
+J*/
+typedef const char* DSType;
+#define DSHEP    "hep"
+#define DSNHEP   "nhep"
+#define DSGHEP   "ghep"
+#define DSGHIEP  "ghiep"
+#define DSGNHEP  "gnhep"
+#define DSNHEPTS "nhepts"
+#define DSSVD    "svd"
+#define DSHSVD   "hsvd"
+#define DSGSVD   "gsvd"
+#define DSPEP    "pep"
+#define DSNEP    "nep"
+
+/* Logging support */
+SLEPC_EXTERN PetscClassId DS_CLASSID;
+
+/*E
+    DSStateType - Indicates in which state the direct solver is
+
+    Level: advanced
+
+.seealso: DSSetState()
+E*/
+typedef enum { DS_STATE_RAW,
+               DS_STATE_INTERMEDIATE,
+               DS_STATE_CONDENSED,
+               DS_STATE_TRUNCATED } DSStateType;
+SLEPC_EXTERN const char *DSStateTypes[];
+
+/*E
+    DSMatType - Used to refer to one of the matrices stored internally in DS
+
+    Notes:
+    The matrices preferentially refer to
++   DS_MAT_A  - first matrix of eigenproblem/singular value problem
+.   DS_MAT_B  - second matrix of a generalized eigenproblem
+.   DS_MAT_C  - third matrix of a quadratic eigenproblem (deprecated)
+.   DS_MAT_T  - tridiagonal matrix
+.   DS_MAT_D  - diagonal matrix
+.   DS_MAT_Q  - orthogonal matrix of (right) Schur vectors
+.   DS_MAT_Z  - orthogonal matrix of left Schur vectors
+.   DS_MAT_X  - right eigenvectors
+.   DS_MAT_Y  - left eigenvectors
+.   DS_MAT_U  - left singular vectors
+.   DS_MAT_V  - right singular vectors
+.   DS_MAT_W  - workspace matrix
+-   DS_MAT_Ex - extra matrices (x=0,..,9)
+
+    All matrices can have space to hold ld x ld elements, except for
+    DS_MAT_T that has space for 3 x ld elements (ld = leading dimension)
+    and DS_MAT_D that has space for just ld elements.
+
+    In DSPEP problems, matrices A, B, W can have space for d*ld x d*ld,
+    where d is the polynomial degree, and X can have ld x d*ld.
+    Also DSNEP has exceptions. Check the manual page of each DS type
+    for details.
+
+    Level: advanced
+
+.seealso: DSAllocate(), DSGetArray(), DSGetArrayReal(), DSVectors()
+E*/
+typedef enum { DS_MAT_A,
+               DS_MAT_B,
+               DS_MAT_C,
+               DS_MAT_T,
+               DS_MAT_D,
+               DS_MAT_Q,
+               DS_MAT_Z,
+               DS_MAT_X,
+               DS_MAT_Y,
+               DS_MAT_U,
+               DS_MAT_V,
+               DS_MAT_W,
+               DS_MAT_E0,
+               DS_MAT_E1,
+               DS_MAT_E2,
+               DS_MAT_E3,
+               DS_MAT_E4,
+               DS_MAT_E5,
+               DS_MAT_E6,
+               DS_MAT_E7,
+               DS_MAT_E8,
+               DS_MAT_E9,
+               DS_NUM_MAT } DSMatType;
+
+/* Convenience for indexing extra matrices */
+SLEPC_EXTERN DSMatType DSMatExtra[];
+#define DS_NUM_EXTRA  10
+
+/*E
+    DSParallelType - Indicates the parallel mode that the direct solver will use
+
+    Level: advanced
+
+.seealso: DSSetParallel()
+E*/
+typedef enum { DS_PARALLEL_REDUNDANT,
+               DS_PARALLEL_SYNCHRONIZED,
+               DS_PARALLEL_DISTRIBUTED } DSParallelType;
+SLEPC_EXTERN const char *DSParallelTypes[];
+
+SLEPC_EXTERN PetscErrorCode DSCreate(MPI_Comm,DS*);
+SLEPC_EXTERN PetscErrorCode DSSetType(DS,DSType);
+SLEPC_EXTERN PetscErrorCode DSGetType(DS,DSType*);
+SLEPC_EXTERN PetscErrorCode DSSetOptionsPrefix(DS,const char *);
+SLEPC_EXTERN PetscErrorCode DSAppendOptionsPrefix(DS,const char *);
+SLEPC_EXTERN PetscErrorCode DSGetOptionsPrefix(DS,const char *[]);
+SLEPC_EXTERN PetscErrorCode DSSetFromOptions(DS);
+SLEPC_EXTERN PetscErrorCode DSView(DS,PetscViewer);
+SLEPC_EXTERN PetscErrorCode DSViewFromOptions(DS,PetscObject,const char[]);
+SLEPC_EXTERN PetscErrorCode DSViewMat(DS,PetscViewer,DSMatType);
+SLEPC_EXTERN PetscErrorCode DSDestroy(DS*);
+SLEPC_EXTERN PetscErrorCode DSReset(DS);
+SLEPC_EXTERN PetscErrorCode DSDuplicate(DS,DS*);
+
+SLEPC_EXTERN PetscErrorCode DSAllocate(DS,PetscInt);
+SLEPC_EXTERN PetscErrorCode DSGetLeadingDimension(DS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSSetState(DS,DSStateType);
+SLEPC_EXTERN PetscErrorCode DSGetState(DS,DSStateType*);
+SLEPC_EXTERN PetscErrorCode DSSetDimensions(DS,PetscInt,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode DSGetDimensions(DS,PetscInt*,PetscInt*,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSSetBlockSize(DS,PetscInt);
+SLEPC_EXTERN PetscErrorCode DSGetBlockSize(DS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSGetTruncateSize(DS,PetscInt,PetscInt,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSTruncate(DS,PetscInt,PetscBool);
+SLEPC_EXTERN PetscErrorCode DSSetIdentity(DS,DSMatType);
+SLEPC_EXTERN PetscErrorCode DSSetMethod(DS,PetscInt);
+SLEPC_EXTERN PetscErrorCode DSGetMethod(DS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSSetParallel(DS,DSParallelType);
+SLEPC_EXTERN PetscErrorCode DSGetParallel(DS,DSParallelType*);
+SLEPC_EXTERN PetscErrorCode DSSetCompact(DS,PetscBool);
+SLEPC_EXTERN PetscErrorCode DSGetCompact(DS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode DSSetExtraRow(DS,PetscBool);
+SLEPC_EXTERN PetscErrorCode DSGetExtraRow(DS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode DSSetRefined(DS,PetscBool);
+SLEPC_EXTERN PetscErrorCode DSGetRefined(DS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode DSGetMat(DS,DSMatType,Mat*);
+SLEPC_EXTERN PetscErrorCode DSRestoreMat(DS,DSMatType,Mat*);
+SLEPC_EXTERN PetscErrorCode DSGetMatAndColumn(DS,DSMatType,PetscInt,Mat*,Vec*);
+SLEPC_EXTERN PetscErrorCode DSRestoreMatAndColumn(DS,DSMatType,PetscInt,Mat*,Vec*);
+SLEPC_EXTERN PetscErrorCode DSGetArray(DS,DSMatType,PetscScalar*[]);
+SLEPC_EXTERN PetscErrorCode DSRestoreArray(DS,DSMatType,PetscScalar*[]);
+SLEPC_EXTERN PetscErrorCode DSGetArrayReal(DS,DSMatType,PetscReal*[]);
+SLEPC_EXTERN PetscErrorCode DSRestoreArrayReal(DS,DSMatType,PetscReal*[]);
+SLEPC_EXTERN PetscErrorCode DSVectors(DS,DSMatType,PetscInt*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode DSSolve(DS,PetscScalar*,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode DSSort(DS,PetscScalar*,PetscScalar*,PetscScalar*,PetscScalar*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSSortWithPermutation(DS,PetscInt*,PetscScalar*,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode DSSynchronize(DS,PetscScalar*,PetscScalar*);
+PETSC_DEPRECATED_FUNCTION(3, 18, 0, "DSGetMat()+MatDenseGetSubMatrix()+MatCopy()", ) static inline PetscErrorCode DSCopyMat(DS ds,DSMatType m,PetscInt mr,PetscInt mc,Mat A,PetscInt Ar,PetscInt Ac,PetscInt rows,PetscInt cols,PetscBool out)
+{
+  Mat M,M0,A0;
+
+  PetscFunctionBegin;
+  PetscCall(DSGetMat(ds,m,&M));
+  PetscCall(MatDenseGetSubMatrix(M,mr,mr+rows,mc,mc+cols,&M0));
+  PetscCall(MatDenseGetSubMatrix(A,Ar,Ar+rows,Ac,Ac+cols,&A0));
+  if (out) PetscCall(MatCopy(M0,A0,SAME_NONZERO_PATTERN));
+  else PetscCall(MatCopy(A0,M0,SAME_NONZERO_PATTERN));
+  PetscCall(MatDenseRestoreSubMatrix(M,&M0));
+  PetscCall(MatDenseRestoreSubMatrix(A,&A0));
+  PetscCall(DSRestoreMat(ds,m,&M));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+SLEPC_EXTERN PetscErrorCode DSMatGetSize(DS,DSMatType,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSMatIsHermitian(DS,DSMatType,PetscBool*);
+SLEPC_EXTERN PetscErrorCode DSSetSlepcSC(DS,SlepcSC);
+SLEPC_EXTERN PetscErrorCode DSGetSlepcSC(DS,SlepcSC*);
+SLEPC_EXTERN PetscErrorCode DSUpdateExtraRow(DS);
+SLEPC_EXTERN PetscErrorCode DSCond(DS,PetscReal*);
+SLEPC_EXTERN PetscErrorCode DSTranslateHarmonic(DS,PetscScalar,PetscReal,PetscBool,PetscScalar*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode DSTranslateRKS(DS,PetscScalar);
+SLEPC_EXTERN PetscErrorCode DSOrthogonalize(DS,DSMatType,PetscInt,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSPseudoOrthogonalize(DS,DSMatType,PetscInt,PetscReal*,PetscInt*,PetscReal*);
+
+/* --------- options specific to particular solvers -------- */
+
+SLEPC_EXTERN PetscErrorCode DSSVDSetDimensions(DS,PetscInt);
+SLEPC_EXTERN PetscErrorCode DSSVDGetDimensions(DS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSGSVDSetDimensions(DS,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode DSGSVDGetDimensions(DS,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSHSVDSetDimensions(DS,PetscInt);
+SLEPC_EXTERN PetscErrorCode DSHSVDGetDimensions(DS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSHSVDSetReorthogonalize(DS,PetscBool);
+SLEPC_EXTERN PetscErrorCode DSHSVDGetReorthogonalize(DS,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode DSPEPSetDegree(DS,PetscInt);
+SLEPC_EXTERN PetscErrorCode DSPEPGetDegree(DS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSPEPSetCoefficients(DS,PetscReal*);
+SLEPC_EXTERN PetscErrorCode DSPEPGetCoefficients(DS,PetscReal**);
+
+SLEPC_EXTERN PetscErrorCode DSNEPSetFN(DS,PetscInt,FN*);
+SLEPC_EXTERN PetscErrorCode DSNEPGetFN(DS,PetscInt,FN*);
+SLEPC_EXTERN PetscErrorCode DSNEPGetNumFN(DS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSNEPSetMinimality(DS,PetscInt);
+SLEPC_EXTERN PetscErrorCode DSNEPGetMinimality(DS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSNEPSetRefine(DS,PetscReal,PetscInt);
+SLEPC_EXTERN PetscErrorCode DSNEPGetRefine(DS,PetscReal*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSNEPSetIntegrationPoints(DS,PetscInt);
+SLEPC_EXTERN PetscErrorCode DSNEPGetIntegrationPoints(DS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSNEPSetSamplingSize(DS,PetscInt);
+SLEPC_EXTERN PetscErrorCode DSNEPGetSamplingSize(DS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode DSNEPSetRG(DS,RG);
+SLEPC_EXTERN PetscErrorCode DSNEPGetRG(DS,RG*);
+
+/*S
+  DSNEPMatrixFunctionFn - A prototype of a DSNEP compute matrix function that would be passed to DSNEPSetComputeMatrixFunction()
+
+  Calling Sequence:
++   ds     - the direct solver object
+.   lambda - point where T(lambda) or T'(lambda) must be evaluated
+.   deriv  - if true compute T'(lambda), otherwise compute T(lambda)
+.   mat    - the DS matrix where the result must be stored
+-   ctx    - [optional] user-defined context for private data for the
+             matrix evaluation routine (may be `NULL`)
+
+  Level: developer
+
+.seealso: DSNEPSetComputeMatrixFunction()
+S*/
+PETSC_EXTERN_TYPEDEF typedef PetscErrorCode(DSNEPMatrixFunctionFn)(DS ds,PetscScalar lambda,PetscBool deriv,DSMatType mat,void *ctx);
+
+SLEPC_EXTERN PetscErrorCode DSNEPSetComputeMatrixFunction(DS,DSNEPMatrixFunctionFn*,void*);
+SLEPC_EXTERN PetscErrorCode DSNEPGetComputeMatrixFunction(DS,DSNEPMatrixFunctionFn**,void**);
+
+SLEPC_EXTERN PetscFunctionList DSList;
+SLEPC_EXTERN PetscErrorCode DSRegister(const char[],PetscErrorCode(*)(DS));

--- a/3rd/slepc/linux/include/slepceps.h
+++ b/3rd/slepc/linux/include/slepceps.h
@@ -1,0 +1,579 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   User interface for the SLEPc linear eigenvalue solvers
+*/
+
+#pragma once
+
+#include <slepcst.h>
+#include <slepcbv.h>
+#include <slepcds.h>
+#include <slepcrg.h>
+#include <slepclme.h>
+#include <petscsnes.h>
+
+/* SUBMANSEC = EPS */
+
+SLEPC_EXTERN PetscErrorCode EPSInitializePackage(void);
+SLEPC_EXTERN PetscErrorCode EPSFinalizePackage(void);
+
+/*S
+    EPS - Abstract SLEPc object that manages all the eigenvalue
+    problem solvers.
+
+    Level: beginner
+
+.seealso:  EPSCreate(), ST
+S*/
+typedef struct _p_EPS* EPS;
+
+/*J
+    EPSType - String with the name of a SLEPc eigensolver
+
+    Level: beginner
+
+.seealso: EPSSetType(), EPS
+J*/
+typedef const char* EPSType;
+#define EPSPOWER       "power"
+#define EPSSUBSPACE    "subspace"
+#define EPSARNOLDI     "arnoldi"
+#define EPSLANCZOS     "lanczos"
+#define EPSKRYLOVSCHUR "krylovschur"
+#define EPSGD          "gd"
+#define EPSJD          "jd"
+#define EPSRQCG        "rqcg"
+#define EPSLOBPCG      "lobpcg"
+#define EPSCISS        "ciss"
+#define EPSLYAPII      "lyapii"
+#define EPSLAPACK      "lapack"
+#define EPSARPACK      "arpack"
+#define EPSTRLAN       "trlan"
+#define EPSBLOPEX      "blopex"
+#define EPSPRIMME      "primme"
+#define EPSFEAST       "feast"
+#define EPSSCALAPACK   "scalapack"
+#define EPSELPA        "elpa"
+#define EPSELEMENTAL   "elemental"
+#define EPSEVSL        "evsl"
+
+/* Logging support */
+SLEPC_EXTERN PetscClassId EPS_CLASSID;
+
+/*E
+    EPSProblemType - Determines the type of eigenvalue problem
+
+    Level: beginner
+
+.seealso: EPSSetProblemType(), EPSGetProblemType()
+E*/
+typedef enum { EPS_HEP=1,
+               EPS_GHEP,
+               EPS_NHEP,
+               EPS_GNHEP,
+               EPS_PGNHEP,
+               EPS_GHIEP,
+               EPS_BSE   } EPSProblemType;
+
+/*E
+    EPSExtraction - Determines the type of extraction technique employed
+    by the eigensolver
+
+    Level: advanced
+
+.seealso: EPSSetExtraction(), EPSGetExtraction()
+E*/
+typedef enum { EPS_RITZ,
+               EPS_HARMONIC,
+               EPS_HARMONIC_RELATIVE,
+               EPS_HARMONIC_RIGHT,
+               EPS_HARMONIC_LARGEST,
+               EPS_REFINED,
+               EPS_REFINED_HARMONIC } EPSExtraction;
+
+/*E
+    EPSWhich - Determines which part of the spectrum is requested
+
+    Level: intermediate
+
+.seealso: EPSSetWhichEigenpairs(), EPSGetWhichEigenpairs()
+E*/
+typedef enum { EPS_LARGEST_MAGNITUDE=1,
+               EPS_SMALLEST_MAGNITUDE,
+               EPS_LARGEST_REAL,
+               EPS_SMALLEST_REAL,
+               EPS_LARGEST_IMAGINARY,
+               EPS_SMALLEST_IMAGINARY,
+               EPS_TARGET_MAGNITUDE,
+               EPS_TARGET_REAL,
+               EPS_TARGET_IMAGINARY,
+               EPS_ALL,
+               EPS_WHICH_USER } EPSWhich;
+
+/*E
+    EPSBalance - The type of balancing used for non-Hermitian problems
+
+    Level: intermediate
+
+.seealso: EPSSetBalance()
+E*/
+typedef enum { EPS_BALANCE_NONE,
+               EPS_BALANCE_ONESIDE,
+               EPS_BALANCE_TWOSIDE,
+               EPS_BALANCE_USER } EPSBalance;
+SLEPC_EXTERN const char *EPSBalanceTypes[];
+
+/*E
+    EPSErrorType - The error type used to assess accuracy of computed solutions
+
+    Level: intermediate
+
+.seealso: EPSComputeError()
+E*/
+typedef enum { EPS_ERROR_ABSOLUTE,
+               EPS_ERROR_RELATIVE,
+               EPS_ERROR_BACKWARD } EPSErrorType;
+SLEPC_EXTERN const char *EPSErrorTypes[];
+
+/*E
+    EPSConv - Determines the convergence test
+
+    Level: intermediate
+
+.seealso: EPSSetConvergenceTest(), EPSSetConvergenceTestFunction()
+E*/
+typedef enum { EPS_CONV_ABS,
+               EPS_CONV_REL,
+               EPS_CONV_NORM,
+               EPS_CONV_USER } EPSConv;
+
+/*E
+    EPSStop - Determines the stopping test
+
+    Level: advanced
+
+.seealso: EPSSetStoppingTest(), EPSSetStoppingTestFunction()
+E*/
+typedef enum { EPS_STOP_BASIC,
+               EPS_STOP_USER } EPSStop;
+
+/*E
+    EPSConvergedReason - Reason an eigensolver was said to
+         have converged or diverged
+
+    Level: intermediate
+
+.seealso: EPSSolve(), EPSGetConvergedReason(), EPSSetTolerances()
+E*/
+typedef enum {/* converged */
+              EPS_CONVERGED_TOL                =  1,
+              EPS_CONVERGED_USER               =  2,
+              /* diverged */
+              EPS_DIVERGED_ITS                 = -1,
+              EPS_DIVERGED_BREAKDOWN           = -2,
+              EPS_DIVERGED_SYMMETRY_LOST       = -3,
+              EPS_CONVERGED_ITERATING          =  0} EPSConvergedReason;
+SLEPC_EXTERN const char *const*EPSConvergedReasons;
+
+SLEPC_EXTERN PetscErrorCode EPSCreate(MPI_Comm,EPS*);
+SLEPC_EXTERN PetscErrorCode EPSDestroy(EPS*);
+SLEPC_EXTERN PetscErrorCode EPSReset(EPS);
+SLEPC_EXTERN PetscErrorCode EPSSetType(EPS,EPSType);
+SLEPC_EXTERN PetscErrorCode EPSGetType(EPS,EPSType*);
+SLEPC_EXTERN PetscErrorCode EPSSetProblemType(EPS,EPSProblemType);
+SLEPC_EXTERN PetscErrorCode EPSGetProblemType(EPS,EPSProblemType*);
+SLEPC_EXTERN PetscErrorCode EPSSetExtraction(EPS,EPSExtraction);
+SLEPC_EXTERN PetscErrorCode EPSGetExtraction(EPS,EPSExtraction*);
+SLEPC_EXTERN PetscErrorCode EPSSetBalance(EPS,EPSBalance,PetscInt,PetscReal);
+SLEPC_EXTERN PetscErrorCode EPSGetBalance(EPS,EPSBalance*,PetscInt*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode EPSSetOperators(EPS,Mat,Mat);
+SLEPC_EXTERN PetscErrorCode EPSGetOperators(EPS,Mat*,Mat*);
+SLEPC_EXTERN PetscErrorCode EPSSetFromOptions(EPS);
+SLEPC_EXTERN PetscErrorCode EPSSetDSType(EPS);
+SLEPC_EXTERN PetscErrorCode EPSSetUp(EPS);
+SLEPC_EXTERN PetscErrorCode EPSSolve(EPS);
+SLEPC_EXTERN PetscErrorCode EPSView(EPS,PetscViewer);
+SLEPC_EXTERN PetscErrorCode EPSViewFromOptions(EPS,PetscObject,const char[]);
+SLEPC_EXTERN PetscErrorCode EPSErrorView(EPS,EPSErrorType,PetscViewer);
+PETSC_DEPRECATED_FUNCTION(3, 6, 0, "EPSErrorView()", ) static inline PetscErrorCode EPSPrintSolution(EPS eps,PetscViewer v) {return EPSErrorView(eps,EPS_ERROR_RELATIVE,v);}
+SLEPC_EXTERN PetscErrorCode EPSErrorViewFromOptions(EPS);
+SLEPC_EXTERN PetscErrorCode EPSConvergedReasonView(EPS,PetscViewer);
+SLEPC_EXTERN PetscErrorCode EPSConvergedReasonViewFromOptions(EPS);
+PETSC_DEPRECATED_FUNCTION(3, 14, 0, "EPSConvergedReasonView()", ) static inline PetscErrorCode EPSReasonView(EPS eps,PetscViewer v) {return EPSConvergedReasonView(eps,v);}
+PETSC_DEPRECATED_FUNCTION(3, 14, 0, "EPSConvergedReasonViewFromOptions()", ) static inline PetscErrorCode EPSReasonViewFromOptions(EPS eps) {return EPSConvergedReasonViewFromOptions(eps);}
+SLEPC_EXTERN PetscErrorCode EPSValuesView(EPS,PetscViewer);
+SLEPC_EXTERN PetscErrorCode EPSValuesViewFromOptions(EPS);
+SLEPC_EXTERN PetscErrorCode EPSVectorsView(EPS,PetscViewer);
+SLEPC_EXTERN PetscErrorCode EPSVectorsViewFromOptions(EPS);
+
+SLEPC_EXTERN PetscErrorCode EPSSetTarget(EPS,PetscScalar);
+SLEPC_EXTERN PetscErrorCode EPSGetTarget(EPS,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode EPSSetInterval(EPS,PetscReal,PetscReal);
+SLEPC_EXTERN PetscErrorCode EPSGetInterval(EPS,PetscReal*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode EPSSetST(EPS,ST);
+SLEPC_EXTERN PetscErrorCode EPSGetST(EPS,ST*);
+SLEPC_EXTERN PetscErrorCode EPSSetBV(EPS,BV);
+SLEPC_EXTERN PetscErrorCode EPSGetBV(EPS,BV*);
+SLEPC_EXTERN PetscErrorCode EPSSetRG(EPS,RG);
+SLEPC_EXTERN PetscErrorCode EPSGetRG(EPS,RG*);
+SLEPC_EXTERN PetscErrorCode EPSSetDS(EPS,DS);
+SLEPC_EXTERN PetscErrorCode EPSGetDS(EPS,DS*);
+SLEPC_EXTERN PetscErrorCode EPSSetTolerances(EPS,PetscReal,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSGetTolerances(EPS,PetscReal*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSSetConvergenceTest(EPS,EPSConv);
+SLEPC_EXTERN PetscErrorCode EPSGetConvergenceTest(EPS,EPSConv*);
+SLEPC_EXTERN PetscErrorCode EPSConvergedAbsolute(EPS,PetscScalar,PetscScalar,PetscReal,PetscReal*,void*);
+SLEPC_EXTERN PetscErrorCode EPSConvergedRelative(EPS,PetscScalar,PetscScalar,PetscReal,PetscReal*,void*);
+SLEPC_EXTERN PetscErrorCode EPSConvergedNorm(EPS,PetscScalar,PetscScalar,PetscReal,PetscReal*,void*);
+SLEPC_EXTERN PetscErrorCode EPSSetStoppingTest(EPS,EPSStop);
+SLEPC_EXTERN PetscErrorCode EPSGetStoppingTest(EPS,EPSStop*);
+SLEPC_EXTERN PetscErrorCode EPSStoppingBasic(EPS,PetscInt,PetscInt,PetscInt,PetscInt,EPSConvergedReason*,void*);
+SLEPC_EXTERN PetscErrorCode EPSGetConvergedReason(EPS,EPSConvergedReason*);
+
+SLEPC_EXTERN PetscErrorCode EPSSetDimensions(EPS,PetscInt,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSGetDimensions(EPS,PetscInt*,PetscInt*,PetscInt*);
+
+SLEPC_EXTERN PetscErrorCode EPSGetConverged(EPS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSGetEigenpair(EPS,PetscInt,PetscScalar*,PetscScalar*,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode EPSGetEigenvalue(EPS,PetscInt,PetscScalar*,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode EPSGetEigenvector(EPS,PetscInt,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode EPSGetLeftEigenvector(EPS,PetscInt,Vec,Vec);
+
+SLEPC_EXTERN PetscErrorCode EPSComputeError(EPS,PetscInt,EPSErrorType,PetscReal*);
+PETSC_DEPRECATED_FUNCTION(3, 6, 0, "EPSComputeError()", ) static inline PetscErrorCode EPSComputeRelativeError(EPS eps,PetscInt i,PetscReal *r) {return EPSComputeError(eps,i,EPS_ERROR_RELATIVE,r);}
+PETSC_DEPRECATED_FUNCTION(3, 6, 0, "EPSComputeError() with EPS_ERROR_ABSOLUTE", ) static inline PetscErrorCode EPSComputeResidualNorm(EPS eps,PetscInt i,PetscReal *r) {return EPSComputeError(eps,i,EPS_ERROR_ABSOLUTE,r);}
+SLEPC_EXTERN PetscErrorCode EPSGetInvariantSubspace(EPS,Vec[]);
+SLEPC_EXTERN PetscErrorCode EPSGetErrorEstimate(EPS,PetscInt,PetscReal*);
+SLEPC_EXTERN PetscErrorCode EPSGetIterationNumber(EPS,PetscInt*);
+
+SLEPC_EXTERN PetscErrorCode EPSSetWhichEigenpairs(EPS,EPSWhich);
+SLEPC_EXTERN PetscErrorCode EPSGetWhichEigenpairs(EPS,EPSWhich*);
+SLEPC_EXTERN PetscErrorCode EPSSetTwoSided(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSGetTwoSided(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSSetTrueResidual(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSGetTrueResidual(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSSetPurify(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSGetPurify(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSIsGeneralized(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSIsHermitian(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSIsPositive(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSIsStructured(EPS,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode EPSSetTrackAll(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSGetTrackAll(EPS,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode EPSSetDeflationSpace(EPS,PetscInt,Vec[]);
+SLEPC_EXTERN PetscErrorCode EPSSetInitialSpace(EPS,PetscInt,Vec[]);
+SLEPC_EXTERN PetscErrorCode EPSSetLeftInitialSpace(EPS,PetscInt,Vec[]);
+
+SLEPC_EXTERN PetscErrorCode EPSMonitor(EPS,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSMonitorSet(EPS,PetscErrorCode (*)(EPS,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,void*),void*,PetscErrorCode (*)(void**));
+SLEPC_EXTERN PetscErrorCode EPSMonitorCancel(EPS);
+SLEPC_EXTERN PetscErrorCode EPSGetMonitorContext(EPS,void*);
+
+SLEPC_EXTERN PetscErrorCode EPSMonitorSetFromOptions(EPS,const char[],const char[],void*,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSMonitorLGCreate(MPI_Comm,const char[],const char[],const char[],PetscInt,const char*[],int,int,int,int,PetscDrawLG*);
+SLEPC_EXTERN PetscErrorCode EPSMonitorFirst(EPS,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode EPSMonitorFirstDrawLG(EPS,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode EPSMonitorFirstDrawLGCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode EPSMonitorAll(EPS,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode EPSMonitorAllDrawLG(EPS,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode EPSMonitorAllDrawLGCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode EPSMonitorConverged(EPS,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode EPSMonitorConvergedCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode EPSMonitorConvergedDrawLG(EPS,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode EPSMonitorConvergedDrawLGCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode EPSMonitorConvergedDestroy(PetscViewerAndFormat**);
+
+SLEPC_EXTERN PetscErrorCode EPSSetOptionsPrefix(EPS,const char*);
+SLEPC_EXTERN PetscErrorCode EPSAppendOptionsPrefix(EPS,const char*);
+SLEPC_EXTERN PetscErrorCode EPSGetOptionsPrefix(EPS,const char*[]);
+
+SLEPC_EXTERN PetscFunctionList EPSList;
+SLEPC_EXTERN PetscFunctionList EPSMonitorList;
+SLEPC_EXTERN PetscFunctionList EPSMonitorCreateList;
+SLEPC_EXTERN PetscFunctionList EPSMonitorDestroyList;
+SLEPC_EXTERN PetscErrorCode EPSRegister(const char[],PetscErrorCode(*)(EPS));
+SLEPC_EXTERN PetscErrorCode EPSMonitorRegister(const char[],PetscViewerType,PetscViewerFormat,PetscErrorCode(*)(EPS,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*),PetscErrorCode(*)(PetscViewer,PetscViewerFormat,void*,PetscViewerAndFormat**),PetscErrorCode(*)(PetscViewerAndFormat**));
+
+SLEPC_EXTERN PetscErrorCode EPSSetWorkVecs(EPS,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSAllocateSolution(EPS,PetscInt);
+
+/*S
+  EPSConvergenceTestFn - A prototype of an EPS convergence test function that would be passed to EPSSetConvergenceTestFunction()
+
+  Calling Sequence:
++   eps    - eigensolver context obtained from EPSCreate()
+.   eigr   - real part of the eigenvalue
+.   eigi   - imaginary part of the eigenvalue
+.   res    - residual norm associated to the eigenpair
+.   errest - [output] computed error estimate
+-   ctx    - [optional] user-defined context for private data for the
+             convergence test routine (may be NULL)
+
+  Level: advanced
+
+.seealso: EPSSetConvergenceTestFunction()
+S*/
+PETSC_EXTERN_TYPEDEF typedef PetscErrorCode(EPSConvergenceTestFn)(EPS eps,PetscScalar eigr,PetscScalar eigi,PetscReal res,PetscReal *errest,void *ctx);
+
+/*S
+  EPSStoppingTestFn - A prototype of an EPS stopping test function that would be passed to EPSSetStoppingTestFunction()
+
+  Calling Sequence:
++   eps    - eigensolver context obtained from EPSCreate()
+.   its    - current number of iterations
+.   max_it - maximum number of iterations
+.   nconv  - number of currently converged eigenpairs
+.   nev    - number of requested eigenpairs
+.   reason - [output] result of the stopping test
+-   ctx    - [optional] user-defined context for private data for the
+             stopping test routine (may be NULL)
+
+  Level: advanced
+
+.seealso: EPSSetStoppingTestFunction()
+S*/
+PETSC_EXTERN_TYPEDEF typedef PetscErrorCode(EPSStoppingTestFn)(EPS eps,PetscInt its,PetscInt max_it,PetscInt nconv,PetscInt nev,EPSConvergedReason *reason,void *ctx);
+
+SLEPC_EXTERN PetscErrorCode EPSSetConvergenceTestFunction(EPS,EPSConvergenceTestFn*,void*,PetscErrorCode (*)(void*));
+SLEPC_EXTERN PetscErrorCode EPSSetStoppingTestFunction(EPS,EPSStoppingTestFn*,void*,PetscErrorCode (*)(void*));
+SLEPC_EXTERN PetscErrorCode EPSSetEigenvalueComparison(EPS,SlepcEigenvalueComparisonFn*,void*);
+SLEPC_EXTERN PetscErrorCode EPSSetArbitrarySelection(EPS,SlepcArbitrarySelectionFn*,void*);
+
+/* --------- options specific to particular eigensolvers -------- */
+
+/*E
+    EPSPowerShiftType - determines the type of shift used in the Power iteration
+
+    Level: advanced
+
+.seealso: EPSPowerSetShiftType(), EPSPowerGetShiftType()
+E*/
+typedef enum { EPS_POWER_SHIFT_CONSTANT,
+               EPS_POWER_SHIFT_RAYLEIGH,
+               EPS_POWER_SHIFT_WILKINSON } EPSPowerShiftType;
+SLEPC_EXTERN const char *EPSPowerShiftTypes[];
+
+SLEPC_EXTERN PetscErrorCode EPSPowerSetShiftType(EPS,EPSPowerShiftType);
+SLEPC_EXTERN PetscErrorCode EPSPowerGetShiftType(EPS,EPSPowerShiftType*);
+SLEPC_EXTERN PetscErrorCode EPSPowerSetNonlinear(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSPowerGetNonlinear(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSPowerSetUpdate(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSPowerGetUpdate(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSPowerSetSignNormalization(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSPowerGetSignNormalization(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSPowerSetSNES(EPS,SNES);
+SLEPC_EXTERN PetscErrorCode EPSPowerGetSNES(EPS,SNES*);
+
+SLEPC_EXTERN PetscErrorCode EPSArnoldiSetDelayed(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSArnoldiGetDelayed(EPS,PetscBool*);
+
+/*E
+    EPSKrylovSchurBSEType - the method to be used in the Krylov-Schur solver
+    for the case of BSE structured eigenproblems
+
+    Level: advanced
+
+.seealso: EPSKrylovSchurSetBSEType(), EPSKrylovSchurGetBSEType()
+E*/
+typedef enum { EPS_KRYLOVSCHUR_BSE_SHAO,
+               EPS_KRYLOVSCHUR_BSE_GRUNING,
+               EPS_KRYLOVSCHUR_BSE_PROJECTEDBSE } EPSKrylovSchurBSEType;
+SLEPC_EXTERN const char *EPSKrylovSchurBSETypes[];
+
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurSetBSEType(EPS,EPSKrylovSchurBSEType);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurGetBSEType(EPS,EPSKrylovSchurBSEType*);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurSetRestart(EPS,PetscReal);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurGetRestart(EPS,PetscReal*);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurSetLocking(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurGetLocking(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurSetPartitions(EPS,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurGetPartitions(EPS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurSetDetectZeros(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurGetDetectZeros(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurSetDimensions(EPS,PetscInt,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurGetDimensions(EPS,PetscInt*,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurSetSubintervals(EPS,PetscReal*);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurGetSubintervals(EPS,PetscReal**);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurGetInertias(EPS,PetscInt*,PetscReal**,PetscInt**);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurGetSubcommInfo(EPS,PetscInt*,PetscInt*,Vec*);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurGetSubcommPairs(EPS,PetscInt,PetscScalar*,Vec);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurGetSubcommMats(EPS,Mat*,Mat*);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurUpdateSubcommMats(EPS,PetscScalar,PetscScalar,Mat,PetscScalar,PetscScalar, Mat,MatStructure,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSKrylovSchurGetKSP(EPS,KSP*);
+
+/*E
+    EPSLanczosReorthogType - determines the type of reorthogonalization
+    used in the Lanczos method
+
+    Level: advanced
+
+.seealso: EPSLanczosSetReorthog(), EPSLanczosGetReorthog()
+E*/
+typedef enum { EPS_LANCZOS_REORTHOG_LOCAL,
+               EPS_LANCZOS_REORTHOG_FULL,
+               EPS_LANCZOS_REORTHOG_SELECTIVE,
+               EPS_LANCZOS_REORTHOG_PERIODIC,
+               EPS_LANCZOS_REORTHOG_PARTIAL,
+               EPS_LANCZOS_REORTHOG_DELAYED } EPSLanczosReorthogType;
+SLEPC_EXTERN const char *EPSLanczosReorthogTypes[];
+
+SLEPC_EXTERN PetscErrorCode EPSLanczosSetReorthog(EPS,EPSLanczosReorthogType);
+SLEPC_EXTERN PetscErrorCode EPSLanczosGetReorthog(EPS,EPSLanczosReorthogType*);
+
+/*E
+    EPSPRIMMEMethod - determines the method selected in the PRIMME library
+
+    Level: advanced
+
+.seealso: EPSPRIMMESetMethod(), EPSPRIMMEGetMethod()
+E*/
+typedef enum { EPS_PRIMME_DYNAMIC=1,
+               EPS_PRIMME_DEFAULT_MIN_TIME,
+               EPS_PRIMME_DEFAULT_MIN_MATVECS,
+               EPS_PRIMME_ARNOLDI,
+               EPS_PRIMME_GD,
+               EPS_PRIMME_GD_PLUSK,
+               EPS_PRIMME_GD_OLSEN_PLUSK,
+               EPS_PRIMME_JD_OLSEN_PLUSK,
+               EPS_PRIMME_RQI,
+               EPS_PRIMME_JDQR,
+               EPS_PRIMME_JDQMR,
+               EPS_PRIMME_JDQMR_ETOL,
+               EPS_PRIMME_SUBSPACE_ITERATION,
+               EPS_PRIMME_LOBPCG_ORTHOBASIS,
+               EPS_PRIMME_LOBPCG_ORTHOBASISW } EPSPRIMMEMethod;
+SLEPC_EXTERN const char *EPSPRIMMEMethods[];
+
+SLEPC_EXTERN PetscErrorCode EPSPRIMMESetBlockSize(EPS,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSPRIMMEGetBlockSize(EPS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSPRIMMESetMethod(EPS,EPSPRIMMEMethod);
+SLEPC_EXTERN PetscErrorCode EPSPRIMMEGetMethod(EPS,EPSPRIMMEMethod*);
+
+SLEPC_EXTERN PetscErrorCode EPSGDSetKrylovStart(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSGDGetKrylovStart(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSGDSetBlockSize(EPS,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSGDGetBlockSize(EPS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSGDSetRestart(EPS,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSGDGetRestart(EPS,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSGDSetInitialSize(EPS,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSGDGetInitialSize(EPS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSGDSetBOrth(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSGDGetBOrth(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSGDSetDoubleExpansion(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSGDGetDoubleExpansion(EPS,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode EPSJDSetKrylovStart(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSJDGetKrylovStart(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSJDSetBlockSize(EPS,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSJDGetBlockSize(EPS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSJDSetRestart(EPS,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSJDGetRestart(EPS,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSJDSetInitialSize(EPS,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSJDGetInitialSize(EPS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSJDSetFix(EPS,PetscReal);
+SLEPC_EXTERN PetscErrorCode EPSJDGetFix(EPS,PetscReal*);
+SLEPC_EXTERN PetscErrorCode EPSJDSetConstCorrectionTol(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSJDGetConstCorrectionTol(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSJDSetBOrth(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSJDGetBOrth(EPS,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode EPSRQCGSetReset(EPS,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSRQCGGetReset(EPS,PetscInt*);
+
+SLEPC_EXTERN PetscErrorCode EPSLOBPCGSetBlockSize(EPS,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSLOBPCGGetBlockSize(EPS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSLOBPCGSetRestart(EPS,PetscReal);
+SLEPC_EXTERN PetscErrorCode EPSLOBPCGGetRestart(EPS,PetscReal*);
+SLEPC_EXTERN PetscErrorCode EPSLOBPCGSetLocking(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSLOBPCGGetLocking(EPS,PetscBool*);
+
+/*E
+    EPSCISSQuadRule - determines the quadrature rule in the CISS solver
+
+    Level: advanced
+
+.seealso: EPSCISSSetQuadRule(), EPSCISSGetQuadRule()
+E*/
+typedef enum { EPS_CISS_QUADRULE_TRAPEZOIDAL=1,
+               EPS_CISS_QUADRULE_CHEBYSHEV } EPSCISSQuadRule;
+SLEPC_EXTERN const char *EPSCISSQuadRules[];
+
+/*E
+    EPSCISSExtraction - determines the extraction technique in the CISS solver
+
+    Level: advanced
+
+.seealso: EPSCISSSetExtraction(), EPSCISSGetExtraction()
+E*/
+typedef enum { EPS_CISS_EXTRACTION_RITZ,
+               EPS_CISS_EXTRACTION_HANKEL } EPSCISSExtraction;
+SLEPC_EXTERN const char *EPSCISSExtractions[];
+
+SLEPC_EXTERN PetscErrorCode EPSCISSSetExtraction(EPS,EPSCISSExtraction);
+SLEPC_EXTERN PetscErrorCode EPSCISSGetExtraction(EPS,EPSCISSExtraction*);
+SLEPC_EXTERN PetscErrorCode EPSCISSSetQuadRule(EPS,EPSCISSQuadRule);
+SLEPC_EXTERN PetscErrorCode EPSCISSGetQuadRule(EPS,EPSCISSQuadRule*);
+SLEPC_EXTERN PetscErrorCode EPSCISSSetSizes(EPS,PetscInt,PetscInt,PetscInt,PetscInt,PetscInt,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSCISSGetSizes(EPS,PetscInt*,PetscInt*,PetscInt*,PetscInt*,PetscInt*,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSCISSSetThreshold(EPS,PetscReal,PetscReal);
+SLEPC_EXTERN PetscErrorCode EPSCISSGetThreshold(EPS,PetscReal*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode EPSCISSSetRefinement(EPS,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSCISSGetRefinement(EPS,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSCISSSetUseST(EPS,PetscBool);
+SLEPC_EXTERN PetscErrorCode EPSCISSGetUseST(EPS,PetscBool*);
+SLEPC_EXTERN PetscErrorCode EPSCISSGetKSPs(EPS,PetscInt*,KSP**);
+
+SLEPC_EXTERN PetscErrorCode EPSLyapIISetLME(EPS,LME);
+SLEPC_EXTERN PetscErrorCode EPSLyapIIGetLME(EPS,LME*);
+SLEPC_EXTERN PetscErrorCode EPSLyapIISetRanks(EPS,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSLyapIIGetRanks(EPS,PetscInt*,PetscInt*);
+
+SLEPC_EXTERN PetscErrorCode EPSBLOPEXSetBlockSize(EPS,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSBLOPEXGetBlockSize(EPS,PetscInt*);
+
+/*E
+    EPSEVSLDOSMethod - the method to approximate the density of states (DOS) in the EVSL solver
+
+    Level: advanced
+
+.seealso: EPSEVSLSetDOSParameters(), EPSEVSLGetDOSParameters()
+E*/
+typedef enum { EPS_EVSL_DOS_KPM,
+               EPS_EVSL_DOS_LANCZOS } EPSEVSLDOSMethod;
+SLEPC_EXTERN const char *EPSEVSLDOSMethods[];
+
+/*E
+    EPSEVSLDamping - the damping type used in the EVSL solver
+
+    Level: advanced
+
+.seealso: EPSEVSLSetDOSParameters(), EPSEVSLGetDOSParameters()
+E*/
+typedef enum { EPS_EVSL_DAMPING_NONE,
+               EPS_EVSL_DAMPING_JACKSON,
+               EPS_EVSL_DAMPING_SIGMA } EPSEVSLDamping;
+SLEPC_EXTERN const char *EPSEVSLDampings[];
+
+SLEPC_EXTERN PetscErrorCode EPSEVSLSetRange(EPS,PetscReal,PetscReal);
+SLEPC_EXTERN PetscErrorCode EPSEVSLGetRange(EPS,PetscReal*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode EPSEVSLSetSlices(EPS,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSEVSLGetSlices(EPS,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSEVSLSetDOSParameters(EPS,EPSEVSLDOSMethod,PetscInt,PetscInt,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSEVSLGetDOSParameters(EPS,EPSEVSLDOSMethod*,PetscInt*,PetscInt*,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode EPSEVSLSetPolParameters(EPS,PetscInt,PetscReal);
+SLEPC_EXTERN PetscErrorCode EPSEVSLGetPolParameters(EPS,PetscInt*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode EPSEVSLSetDamping(EPS,EPSEVSLDamping);
+SLEPC_EXTERN PetscErrorCode EPSEVSLGetDamping(EPS,EPSEVSLDamping*);
+
+SLEPC_EXTERN PetscErrorCode EPSFEASTSetNumPoints(EPS,PetscInt);
+SLEPC_EXTERN PetscErrorCode EPSFEASTGetNumPoints(EPS,PetscInt*);

--- a/3rd/slepc/linux/include/slepcfn.h
+++ b/3rd/slepc/linux/include/slepcfn.h
@@ -1,0 +1,114 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   User interface for the mathematical function object in SLEPc
+*/
+
+#pragma once
+
+#include <slepcsys.h>
+
+/* SUBMANSEC = FN */
+
+#define FN_MAX_SOLVE 16
+
+SLEPC_EXTERN PetscErrorCode FNInitializePackage(void);
+SLEPC_EXTERN PetscErrorCode FNFinalizePackage(void);
+
+/*S
+   FN - Abstraction of a mathematical function.
+
+   Level: beginner
+
+.seealso: FNCreate()
+S*/
+typedef struct _p_FN* FN;
+
+/*J
+   FNType - String with the name of the mathematical function.
+
+   Level: beginner
+
+.seealso: FNSetType(), FN
+J*/
+typedef const char* FNType;
+#define FNCOMBINE  "combine"
+#define FNRATIONAL "rational"
+#define FNEXP      "exp"
+#define FNLOG      "log"
+#define FNPHI      "phi"
+#define FNSQRT     "sqrt"
+#define FNINVSQRT  "invsqrt"
+
+/* Logging support */
+SLEPC_EXTERN PetscClassId FN_CLASSID;
+
+/*E
+    FNCombineType - Determines how two functions are combined
+
+    Level: advanced
+
+.seealso: FNCombineSetChildren()
+E*/
+typedef enum { FN_COMBINE_ADD,
+               FN_COMBINE_MULTIPLY,
+               FN_COMBINE_DIVIDE,
+               FN_COMBINE_COMPOSE } FNCombineType;
+
+/*E
+    FNParallelType - Indicates the parallel mode that will be used for matrix evaluation
+
+    Level: advanced
+
+.seealso: FNSetParallel()
+E*/
+typedef enum { FN_PARALLEL_REDUNDANT,
+               FN_PARALLEL_SYNCHRONIZED } FNParallelType;
+SLEPC_EXTERN const char *FNParallelTypes[];
+
+SLEPC_EXTERN PetscErrorCode FNCreate(MPI_Comm,FN*);
+SLEPC_EXTERN PetscErrorCode FNSetType(FN,FNType);
+SLEPC_EXTERN PetscErrorCode FNGetType(FN,FNType*);
+SLEPC_EXTERN PetscErrorCode FNSetOptionsPrefix(FN,const char *);
+SLEPC_EXTERN PetscErrorCode FNAppendOptionsPrefix(FN,const char *);
+SLEPC_EXTERN PetscErrorCode FNGetOptionsPrefix(FN,const char *[]);
+SLEPC_EXTERN PetscErrorCode FNSetFromOptions(FN);
+SLEPC_EXTERN PetscErrorCode FNView(FN,PetscViewer);
+SLEPC_EXTERN PetscErrorCode FNViewFromOptions(FN,PetscObject,const char[]);
+SLEPC_EXTERN PetscErrorCode FNDestroy(FN*);
+SLEPC_EXTERN PetscErrorCode FNDuplicate(FN,MPI_Comm,FN*);
+
+SLEPC_EXTERN PetscErrorCode FNSetScale(FN,PetscScalar,PetscScalar);
+SLEPC_EXTERN PetscErrorCode FNGetScale(FN,PetscScalar*,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode FNSetMethod(FN,PetscInt);
+SLEPC_EXTERN PetscErrorCode FNGetMethod(FN,PetscInt*);
+SLEPC_EXTERN PetscErrorCode FNSetParallel(FN,FNParallelType);
+SLEPC_EXTERN PetscErrorCode FNGetParallel(FN,FNParallelType*);
+
+SLEPC_EXTERN PetscErrorCode FNEvaluateFunction(FN,PetscScalar,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode FNEvaluateDerivative(FN,PetscScalar,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode FNEvaluateFunctionMat(FN,Mat,Mat);
+SLEPC_EXTERN PetscErrorCode FNEvaluateFunctionMatVec(FN,Mat,Vec);
+
+SLEPC_EXTERN PetscFunctionList FNList;
+SLEPC_EXTERN PetscErrorCode FNRegister(const char[],PetscErrorCode(*)(FN));
+
+/* --------- options specific to particular functions -------- */
+
+SLEPC_EXTERN PetscErrorCode FNRationalSetNumerator(FN,PetscInt,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode FNRationalGetNumerator(FN,PetscInt*,PetscScalar**);
+SLEPC_EXTERN PetscErrorCode FNRationalSetDenominator(FN,PetscInt,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode FNRationalGetDenominator(FN,PetscInt*,PetscScalar**);
+
+SLEPC_EXTERN PetscErrorCode FNCombineSetChildren(FN,FNCombineType,FN,FN);
+SLEPC_EXTERN PetscErrorCode FNCombineGetChildren(FN,FNCombineType*,FN*,FN*);
+
+SLEPC_EXTERN PetscErrorCode FNPhiSetIndex(FN,PetscInt);
+SLEPC_EXTERN PetscErrorCode FNPhiGetIndex(FN,PetscInt*);

--- a/3rd/slepc/linux/include/slepclme.h
+++ b/3rd/slepc/linux/include/slepclme.h
@@ -1,0 +1,140 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   User interface for the SLEPc object for solving linear matrix equations
+*/
+
+#pragma once
+
+#include <slepcbv.h>
+
+/* SUBMANSEC = LME */
+
+SLEPC_EXTERN PetscErrorCode LMEInitializePackage(void);
+SLEPC_EXTERN PetscErrorCode LMEFinalizePackage(void);
+
+/*S
+    LME - SLEPc object that encapsulates functionality for linear matrix equations
+
+    Level: beginner
+
+.seealso:  LMECreate()
+S*/
+typedef struct _p_LME* LME;
+
+/*J
+    LMEType - String with the name of a method for solving linear matrix equations
+
+    Level: beginner
+
+.seealso: LMESetType(), LME
+J*/
+typedef const char* LMEType;
+#define LMEKRYLOV   "krylov"
+
+/* Logging support */
+SLEPC_EXTERN PetscClassId LME_CLASSID;
+
+/*E
+    LMEProblemType - Determines the type of linear matrix equation
+
+    Level: beginner
+
+.seealso: LMESetProblemType(), LMEGetProblemType()
+E*/
+typedef enum { LME_LYAPUNOV,
+               LME_SYLVESTER,
+               LME_GEN_LYAPUNOV,
+               LME_GEN_SYLVESTER,
+               LME_DT_LYAPUNOV ,
+               LME_STEIN} LMEProblemType;
+SLEPC_EXTERN const char *LMEProblemTypes[];
+
+SLEPC_EXTERN PetscErrorCode LMECreate(MPI_Comm,LME *);
+SLEPC_EXTERN PetscErrorCode LMEDestroy(LME*);
+SLEPC_EXTERN PetscErrorCode LMEReset(LME);
+SLEPC_EXTERN PetscErrorCode LMESetType(LME,LMEType);
+SLEPC_EXTERN PetscErrorCode LMEGetType(LME,LMEType*);
+SLEPC_EXTERN PetscErrorCode LMESetProblemType(LME,LMEProblemType);
+SLEPC_EXTERN PetscErrorCode LMEGetProblemType(LME,LMEProblemType*);
+SLEPC_EXTERN PetscErrorCode LMESetCoefficients(LME,Mat,Mat,Mat,Mat);
+SLEPC_EXTERN PetscErrorCode LMEGetCoefficients(LME,Mat*,Mat*,Mat*,Mat*);
+SLEPC_EXTERN PetscErrorCode LMESetRHS(LME,Mat);
+SLEPC_EXTERN PetscErrorCode LMEGetRHS(LME,Mat*);
+SLEPC_EXTERN PetscErrorCode LMESetSolution(LME,Mat);
+SLEPC_EXTERN PetscErrorCode LMEGetSolution(LME,Mat*);
+SLEPC_EXTERN PetscErrorCode LMESetFromOptions(LME);
+SLEPC_EXTERN PetscErrorCode LMESetUp(LME);
+SLEPC_EXTERN PetscErrorCode LMESolve(LME);
+SLEPC_EXTERN PetscErrorCode LMEView(LME,PetscViewer);
+SLEPC_EXTERN PetscErrorCode LMEViewFromOptions(LME,PetscObject,const char[]);
+SLEPC_EXTERN PetscErrorCode LMEConvergedReasonView(LME,PetscViewer);
+SLEPC_EXTERN PetscErrorCode LMEConvergedReasonViewFromOptions(LME);
+PETSC_DEPRECATED_FUNCTION(3, 14, 0, "LMEConvergedReasonView()", ) static inline PetscErrorCode LMEReasonView(LME lme,PetscViewer v) {return LMEConvergedReasonView(lme,v);}
+PETSC_DEPRECATED_FUNCTION(3, 14, 0, "LMEConvergedReasonViewFromOptions()", ) static inline PetscErrorCode LMEReasonViewFromOptions(LME lme) {return LMEConvergedReasonViewFromOptions(lme);}
+
+SLEPC_EXTERN PetscErrorCode LMESetBV(LME,BV);
+SLEPC_EXTERN PetscErrorCode LMEGetBV(LME,BV*);
+SLEPC_EXTERN PetscErrorCode LMESetTolerances(LME,PetscReal,PetscInt);
+SLEPC_EXTERN PetscErrorCode LMEGetTolerances(LME,PetscReal*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode LMESetDimensions(LME,PetscInt);
+SLEPC_EXTERN PetscErrorCode LMEGetDimensions(LME,PetscInt*);
+SLEPC_EXTERN PetscErrorCode LMEGetIterationNumber(LME,PetscInt*);
+
+SLEPC_EXTERN PetscErrorCode LMEGetErrorEstimate(LME,PetscReal*);
+SLEPC_EXTERN PetscErrorCode LMEComputeError(LME,PetscReal*);
+SLEPC_EXTERN PetscErrorCode LMESetErrorIfNotConverged(LME,PetscBool);
+SLEPC_EXTERN PetscErrorCode LMEGetErrorIfNotConverged(LME,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode LMEDenseLyapunov(LME,PetscInt,PetscScalar*,PetscInt,PetscScalar*,PetscInt,PetscScalar*,PetscInt);
+SLEPC_EXTERN PetscErrorCode LMEDenseHessLyapunovChol(LME,PetscInt,PetscScalar*,PetscInt,PetscInt,PetscScalar*,PetscInt,PetscScalar*,PetscInt,PetscReal*);
+PETSC_DEPRECATED_FUNCTION(3, 8, 0, "LMEDenseHessLyapunovChol()", ) static inline PetscErrorCode LMEDenseLyapunovChol(LME lme,PetscScalar *H,PetscInt m,PetscInt ldh,PetscScalar *r,PetscScalar *L,PetscInt ldl,PetscReal *res) {return LMEDenseHessLyapunovChol(lme,m,H,ldh,1,r,m,L,ldl,res);}
+
+SLEPC_EXTERN PetscErrorCode LMEMonitor(LME,PetscInt,PetscReal);
+SLEPC_EXTERN PetscErrorCode LMEMonitorSet(LME,PetscErrorCode (*)(LME,PetscInt,PetscReal,void*),void*,PetscErrorCode (*)(void**));
+SLEPC_EXTERN PetscErrorCode LMEMonitorCancel(LME);
+SLEPC_EXTERN PetscErrorCode LMEGetMonitorContext(LME,void*);
+
+SLEPC_EXTERN PetscErrorCode LMEMonitorSetFromOptions(LME,const char[],const char[],void*);
+SLEPC_EXTERN PetscErrorCode LMEMonitorLGCreate(MPI_Comm,const char[],const char[],const char[],PetscInt,const char*[],int,int,int,int,PetscDrawLG*);
+SLEPC_EXTERN PetscErrorCode LMEMonitorDefault(LME,PetscInt,PetscReal,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode LMEMonitorDefaultDrawLG(LME,PetscInt,PetscReal,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode LMEMonitorDefaultDrawLGCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+
+SLEPC_EXTERN PetscErrorCode LMESetOptionsPrefix(LME,const char*);
+SLEPC_EXTERN PetscErrorCode LMEAppendOptionsPrefix(LME,const char*);
+SLEPC_EXTERN PetscErrorCode LMEGetOptionsPrefix(LME,const char*[]);
+
+/*E
+    LMEConvergedReason - reason a matrix function iteration was said to
+         have converged or diverged
+
+    Level: intermediate
+
+.seealso: LMESolve(), LMEGetConvergedReason(), LMESetTolerances()
+E*/
+typedef enum {/* converged */
+              LME_CONVERGED_TOL                =  1,
+              /* diverged */
+              LME_DIVERGED_ITS                 = -1,
+              LME_DIVERGED_BREAKDOWN           = -2,
+              LME_CONVERGED_ITERATING          =  0} LMEConvergedReason;
+SLEPC_EXTERN const char *const*LMEConvergedReasons;
+
+SLEPC_EXTERN PetscErrorCode LMEGetConvergedReason(LME,LMEConvergedReason *);
+
+SLEPC_EXTERN PetscFunctionList LMEList;
+SLEPC_EXTERN PetscFunctionList LMEMonitorList;
+SLEPC_EXTERN PetscFunctionList LMEMonitorCreateList;
+SLEPC_EXTERN PetscFunctionList LMEMonitorDestroyList;
+SLEPC_EXTERN PetscErrorCode LMERegister(const char[],PetscErrorCode(*)(LME));
+SLEPC_EXTERN PetscErrorCode LMEMonitorRegister(const char[],PetscViewerType,PetscViewerFormat,PetscErrorCode(*)(LME,PetscInt,PetscReal,PetscViewerAndFormat*),PetscErrorCode(*)(PetscViewer,PetscViewerFormat,void*,PetscViewerAndFormat**),PetscErrorCode(*)(PetscViewerAndFormat**));
+
+SLEPC_EXTERN PetscErrorCode LMEAllocateSolution(LME,PetscInt);

--- a/3rd/slepc/linux/include/slepcmagma.h
+++ b/3rd/slepc/linux/include/slepcmagma.h
@@ -1,0 +1,67 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   Macro definitions to use MAGMA functionality
+*/
+
+#pragma once
+
+#if defined(PETSC_HAVE_MAGMA)
+
+#include <magma_v2.h>
+
+SLEPC_EXTERN PetscErrorCode SlepcMagmaInit(void);
+
+#define PetscCallMAGMA(func, ...) do { \
+    magma_int_t magma_ierr_; \
+    PetscStackPushExternal(PetscStringize(func)); \
+    func(__VA_ARGS__,&magma_ierr_); \
+    PetscStackPop; \
+    PetscCheck(magma_ierr_ == MAGMA_SUCCESS,PETSC_COMM_SELF,PETSC_ERR_LIB,"Error calling %s: error code %d",PetscStringize(func(__VA_ARGS__,&magma_ierr)),(int)magma_ierr_); \
+  } while (0)
+#define CHKERRMAGMA(...) PetscCall(__VA_ARGS__)
+
+#if defined(PETSC_USE_COMPLEX)
+#if defined(PETSC_USE_REAL_SINGLE)
+#define magma_xgeev(a,b,c,d,e,f,g,h,i,j,k,l,m,n) magma_cgeev((a),(b),(c),(magmaFloatComplex*)(d),(e),(magmaFloatComplex*)(f),(magmaFloatComplex*)(g),(h),(magmaFloatComplex*)(i),(j),(magmaFloatComplex*)(k),(l),(m),(n))
+#define magma_xgesv_gpu(a,b,c,d,e,f,g,h)         magma_cgesv_gpu((a),(b),(magmaFloatComplex_ptr)(c),(d),(e),(magmaFloatComplex_ptr)(f),(g),(h))
+#define magma_xgetrf_gpu(a,b,c,d,e,f)   magma_cgetrf_gpu((a),(b),(magmaFloatComplex_ptr)(c),(d),(e),(f))
+#define magma_xgetri_gpu(a,b,c,d,e,f,g) magma_cgetri_gpu((a),(magmaFloatComplex_ptr)(b),(c),(d),(magmaFloatComplex_ptr)(e),(f),(g))
+#define magma_get_xgetri_nb             magma_get_cgetri_nb
+#else
+#define magma_xgeev(a,b,c,d,e,f,g,h,i,j,k,l,m,n) magma_zgeev((a),(b),(c),(magmaDoubleComplex*)(d),(e),(magmaDoubleComplex*)(f),(magmaDoubleComplex*)(g),(h),(magmaDoubleComplex*)(i),(j),(magmaDoubleComplex*)(k),(l),(m),(n))
+#define magma_xgesv_gpu(a,b,c,d,e,f,g,h)         magma_zgesv_gpu((a),(b),(magmaDoubleComplex_ptr)(c),(d),(e),(magmaDoubleComplex_ptr)(f),(g),(h))
+#define magma_xgetrf_gpu(a,b,c,d,e,f)   magma_zgetrf_gpu((a),(b),(magmaDoubleComplex_ptr)(c),(d),(e),(f))
+#define magma_xgetri_gpu(a,b,c,d,e,f,g) magma_zgetri_gpu((a),(magmaDoubleComplex_ptr)(b),(c),(d),(magmaDoubleComplex_ptr)(e),(f),(g))
+#define magma_get_xgetri_nb             magma_get_zgetri_nb
+#endif
+#else
+#if defined(PETSC_USE_REAL_SINGLE)
+#define magma_xgeev                     magma_sgeev
+#define magma_xgesv_gpu                 magma_sgesv_gpu
+#define magma_xgetrf_gpu                magma_sgetrf_gpu
+#define magma_xgetri_gpu                magma_sgetri_gpu
+#define magma_get_xgetri_nb             magma_get_sgetri_nb
+#else
+#define magma_xgeev                     magma_dgeev
+#define magma_xgesv_gpu                 magma_dgesv_gpu
+#define magma_xgetrf_gpu                magma_dgetrf_gpu
+#define magma_xgetri_gpu                magma_dgetri_gpu
+#define magma_get_xgetri_nb             magma_get_dgetri_nb
+#endif
+#endif
+
+#if defined(PETSC_USE_REAL_SINGLE)
+#define magma_Cgesv_gpu(a,b,c,d,e,f,g,h)         magma_cgesv_gpu((a),(b),(magmaFloatComplex_ptr)(c),(d),(e),(magmaFloatComplex_ptr)(f),(g),(h))
+#else
+#define magma_Cgesv_gpu(a,b,c,d,e,f,g,h)         magma_zgesv_gpu((a),(b),(magmaDoubleComplex_ptr)(c),(d),(e),(magmaDoubleComplex_ptr)(f),(g),(h))
+#endif
+
+#endif

--- a/3rd/slepc/linux/include/slepcmat.h
+++ b/3rd/slepc/linux/include/slepcmat.h
@@ -1,0 +1,38 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   User interface for various matrix operations added in SLEPc
+*/
+
+#pragma once
+
+#include <petscmat.h>
+
+/* SUBMANSEC = sys */
+
+SLEPC_EXTERN PetscErrorCode MatCreateTile(PetscScalar,Mat,PetscScalar,Mat,PetscScalar,Mat,PetscScalar,Mat,Mat*);
+SLEPC_EXTERN PetscErrorCode MatCreateVecsEmpty(Mat,Vec*,Vec*);
+SLEPC_EXTERN PetscErrorCode MatNormEstimate(Mat,Vec,Vec,PetscReal*);
+
+/* Matrices for structured eigenproblems */
+SLEPC_EXTERN PetscErrorCode MatCreateBSE(Mat,Mat,Mat*);
+
+/* Deprecated functions */
+PETSC_DEPRECATED_FUNCTION(3, 6, 0, "MatCreateRedundantMatrix() followed by MatConvert()", ) static inline PetscErrorCode SlepcMatConvertSeqDense(Mat mat,Mat *newmat)
+{
+  Mat Ar;
+
+  PetscFunctionBegin;
+  PetscCall(MatCreateRedundantMatrix(mat,0,PETSC_COMM_SELF,MAT_INITIAL_MATRIX,&Ar));
+  PetscCall(MatConvert(Ar,MATSEQDENSE,MAT_INITIAL_MATRIX,newmat));
+  PetscCall(MatDestroy(&Ar));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+PETSC_DEPRECATED_FUNCTION(3, 8, 0, "MatCreateTile()", ) static inline PetscErrorCode SlepcMatTile(PetscScalar a,Mat A,PetscScalar b,Mat B,PetscScalar c,Mat C,PetscScalar d,Mat D,Mat *G) {return MatCreateTile(a,A,b,B,c,C,d,D,G);}

--- a/3rd/slepc/linux/include/slepcmath.h
+++ b/3rd/slepc/linux/include/slepcmath.h
@@ -1,0 +1,121 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   SLEPc mathematics include file. Defines basic operations and functions.
+   This file is included by slepcsys.h and should not be used directly.
+*/
+
+#pragma once
+
+/* SUBMANSEC = sys */
+
+/*
+    Default tolerance for the different solvers, depending on the precision
+*/
+#if defined(PETSC_USE_REAL_SINGLE)
+#  define SLEPC_DEFAULT_TOL   1e-5
+#elif defined(PETSC_USE_REAL_DOUBLE)
+#  define SLEPC_DEFAULT_TOL   1e-8
+#elif defined(PETSC_USE_REAL___FLOAT128)
+#  define SLEPC_DEFAULT_TOL   1e-16
+#elif defined(PETSC_USE_REAL___FP16)
+#  define SLEPC_DEFAULT_TOL   1e-2
+#endif
+
+static inline PetscReal SlepcDefaultTol(PetscReal tol)
+{
+  return tol == (PetscReal)PETSC_DETERMINE ? SLEPC_DEFAULT_TOL : tol;
+}
+
+/*@C
+   SlepcAbs - Returns sqrt(x**2+y**2), taking care not to cause unnecessary
+   overflow. It is based on LAPACK's DLAPY2.
+
+   Not Collective
+
+   Input parameters:
+.  x,y - the real numbers
+
+   Output parameter:
+.  return - the result
+
+   Note:
+   This function is not available from Fortran.
+
+   Level: developer
+@*/
+static inline PetscReal SlepcAbs(PetscReal x,PetscReal y)
+{
+  PetscReal w,z,t,xabs=PetscAbs(x),yabs=PetscAbs(y);
+
+  w = PetscMax(xabs,yabs);
+  z = PetscMin(xabs,yabs);
+  if (PetscUnlikely(z == (PetscReal)0.0)) return w;
+  t = z/w;
+  return w*PetscSqrtReal((PetscReal)1.0+t*t);
+}
+
+/*MC
+   SlepcAbsEigenvalue - Returns the absolute value of a complex number given
+   its real and imaginary parts.
+
+   Synopsis:
+   PetscReal SlepcAbsEigenvalue(PetscScalar x,PetscScalar y)
+
+   Not Collective
+
+   Input parameters:
++  x  - the real part of the complex number
+-  y  - the imaginary part of the complex number
+
+   Notes:
+   This function computes sqrt(x**2+y**2), taking care not to cause unnecessary
+   overflow. It is based on LAPACK's DLAPY2.
+
+   In complex scalars, only the first argument is used.
+
+   This function is not available from Fortran.
+
+   Level: developer
+M*/
+#if !defined(PETSC_USE_COMPLEX)
+#define SlepcAbsEigenvalue(x,y) SlepcAbs(x,y)
+#else
+#define SlepcAbsEigenvalue(x,y) PetscAbsScalar(x)
+#endif
+
+/*
+   SlepcSetFlushToZero - Set the FTZ flag in floating-point arithmetic.
+*/
+static inline PetscErrorCode SlepcSetFlushToZero(unsigned int *state)
+{
+  PetscFunctionBegin;
+#if defined(PETSC_HAVE_XMMINTRIN_H) && defined(_MM_FLUSH_ZERO_ON) && defined(__SSE__)
+  *state = _MM_GET_FLUSH_ZERO_MODE();
+  _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
+#else
+  *state = 0;
+#endif
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   SlepcResetFlushToZero - Reset the FTZ flag in floating-point arithmetic.
+*/
+static inline PetscErrorCode SlepcResetFlushToZero(unsigned int *state)
+{
+  PetscFunctionBegin;
+#if defined(PETSC_HAVE_XMMINTRIN_H) && defined(_MM_FLUSH_ZERO_MASK) && defined(__SSE__)
+  _MM_SET_FLUSH_ZERO_MODE(*state & _MM_FLUSH_ZERO_MASK);
+#else
+  *state = 0;
+#endif
+  PetscFunctionReturn(PETSC_SUCCESS);
+}

--- a/3rd/slepc/linux/include/slepcmfn.h
+++ b/3rd/slepc/linux/include/slepcmfn.h
@@ -1,0 +1,119 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   User interface for the SLEPc matrix function solver object
+*/
+
+#pragma once
+
+#include <slepcbv.h>
+#include <slepcfn.h>
+
+/* SUBMANSEC = MFN */
+
+SLEPC_EXTERN PetscErrorCode MFNInitializePackage(void);
+SLEPC_EXTERN PetscErrorCode MFNFinalizePackage(void);
+
+/*S
+    MFN - SLEPc object that encapsulates functionality for matrix functions.
+
+    Level: beginner
+
+.seealso:  MFNCreate()
+S*/
+typedef struct _p_MFN* MFN;
+
+/*J
+    MFNType - String with the name of a method for computing matrix functions.
+
+    Level: beginner
+
+.seealso: MFNSetType(), MFN
+J*/
+typedef const char* MFNType;
+#define MFNKRYLOV   "krylov"
+#define MFNEXPOKIT  "expokit"
+
+/* Logging support */
+SLEPC_EXTERN PetscClassId MFN_CLASSID;
+
+SLEPC_EXTERN PetscErrorCode MFNCreate(MPI_Comm,MFN *);
+SLEPC_EXTERN PetscErrorCode MFNDestroy(MFN*);
+SLEPC_EXTERN PetscErrorCode MFNReset(MFN);
+SLEPC_EXTERN PetscErrorCode MFNSetType(MFN,MFNType);
+SLEPC_EXTERN PetscErrorCode MFNGetType(MFN,MFNType*);
+SLEPC_EXTERN PetscErrorCode MFNSetOperator(MFN,Mat);
+SLEPC_EXTERN PetscErrorCode MFNGetOperator(MFN,Mat*);
+SLEPC_EXTERN PetscErrorCode MFNSetFromOptions(MFN);
+SLEPC_EXTERN PetscErrorCode MFNSetUp(MFN);
+SLEPC_EXTERN PetscErrorCode MFNSolve(MFN,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode MFNSolveTranspose(MFN,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode MFNView(MFN,PetscViewer);
+SLEPC_EXTERN PetscErrorCode MFNViewFromOptions(MFN,PetscObject,const char[]);
+SLEPC_EXTERN PetscErrorCode MFNConvergedReasonView(MFN,PetscViewer);
+SLEPC_EXTERN PetscErrorCode MFNConvergedReasonViewFromOptions(MFN);
+PETSC_DEPRECATED_FUNCTION(3, 14, 0, "MFNConvergedReasonView()", ) static inline PetscErrorCode MFNReasonView(MFN mfn,PetscViewer v) {return MFNConvergedReasonView(mfn,v);}
+PETSC_DEPRECATED_FUNCTION(3, 14, 0, "MFNConvergedReasonViewFromOptions()", ) static inline PetscErrorCode MFNReasonViewFromOptions(MFN mfn) {return MFNConvergedReasonViewFromOptions(mfn);}
+
+SLEPC_EXTERN PetscErrorCode MFNSetBV(MFN,BV);
+SLEPC_EXTERN PetscErrorCode MFNGetBV(MFN,BV*);
+SLEPC_EXTERN PetscErrorCode MFNSetFN(MFN,FN);
+SLEPC_EXTERN PetscErrorCode MFNGetFN(MFN,FN*);
+SLEPC_EXTERN PetscErrorCode MFNSetTolerances(MFN,PetscReal,PetscInt);
+SLEPC_EXTERN PetscErrorCode MFNGetTolerances(MFN,PetscReal*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode MFNSetDimensions(MFN,PetscInt);
+SLEPC_EXTERN PetscErrorCode MFNGetDimensions(MFN,PetscInt*);
+SLEPC_EXTERN PetscErrorCode MFNGetIterationNumber(MFN,PetscInt*);
+
+SLEPC_EXTERN PetscErrorCode MFNSetErrorIfNotConverged(MFN,PetscBool);
+SLEPC_EXTERN PetscErrorCode MFNGetErrorIfNotConverged(MFN,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode MFNMonitor(MFN,PetscInt,PetscReal);
+SLEPC_EXTERN PetscErrorCode MFNMonitorSet(MFN,PetscErrorCode (*)(MFN,PetscInt,PetscReal,void*),void*,PetscErrorCode (*)(void**));
+SLEPC_EXTERN PetscErrorCode MFNMonitorCancel(MFN);
+SLEPC_EXTERN PetscErrorCode MFNGetMonitorContext(MFN,void*);
+
+SLEPC_EXTERN PetscErrorCode MFNMonitorSetFromOptions(MFN,const char[],const char[],void*);
+SLEPC_EXTERN PetscErrorCode MFNMonitorLGCreate(MPI_Comm,const char[],const char[],const char[],PetscInt,const char*[],int,int,int,int,PetscDrawLG*);
+SLEPC_EXTERN PetscErrorCode MFNMonitorDefault(MFN,PetscInt,PetscReal,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode MFNMonitorDefaultDrawLG(MFN,PetscInt,PetscReal,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode MFNMonitorDefaultDrawLGCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+
+SLEPC_EXTERN PetscErrorCode MFNSetOptionsPrefix(MFN,const char*);
+SLEPC_EXTERN PetscErrorCode MFNAppendOptionsPrefix(MFN,const char*);
+SLEPC_EXTERN PetscErrorCode MFNGetOptionsPrefix(MFN,const char*[]);
+
+/*E
+    MFNConvergedReason - reason a matrix function iteration was said to
+         have converged or diverged
+
+    Level: intermediate
+
+.seealso: MFNSolve(), MFNGetConvergedReason(), MFNSetTolerances()
+E*/
+typedef enum {/* converged */
+              MFN_CONVERGED_TOL                =  1,
+              MFN_CONVERGED_ITS                =  2,
+              /* diverged */
+              MFN_DIVERGED_ITS                 = -1,
+              MFN_DIVERGED_BREAKDOWN           = -2,
+              MFN_CONVERGED_ITERATING          =  0} MFNConvergedReason;
+SLEPC_EXTERN const char *const*MFNConvergedReasons;
+
+SLEPC_EXTERN PetscErrorCode MFNGetConvergedReason(MFN,MFNConvergedReason *);
+
+SLEPC_EXTERN PetscFunctionList MFNList;
+SLEPC_EXTERN PetscFunctionList MFNMonitorList;
+SLEPC_EXTERN PetscFunctionList MFNMonitorCreateList;
+SLEPC_EXTERN PetscFunctionList MFNMonitorDestroyList;
+SLEPC_EXTERN PetscErrorCode MFNRegister(const char[],PetscErrorCode(*)(MFN));
+SLEPC_EXTERN PetscErrorCode MFNMonitorRegister(const char[],PetscViewerType,PetscViewerFormat,PetscErrorCode(*)(MFN,PetscInt,PetscReal,PetscViewerAndFormat*),PetscErrorCode(*)(PetscViewer,PetscViewerFormat,void*,PetscViewerAndFormat**),PetscErrorCode(*)(PetscViewerAndFormat**));
+
+SLEPC_EXTERN PetscErrorCode MFNAllocateSolution(MFN,PetscInt);

--- a/3rd/slepc/linux/include/slepcnep.h
+++ b/3rd/slepc/linux/include/slepcnep.h
@@ -1,0 +1,446 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   User interface for SLEPc's nonlinear eigenvalue solvers
+*/
+
+#pragma once
+
+#include <slepceps.h>
+#include <slepcpep.h>
+#include <slepcfn.h>
+
+/* SUBMANSEC = NEP */
+
+SLEPC_EXTERN PetscErrorCode NEPInitializePackage(void);
+SLEPC_EXTERN PetscErrorCode NEPFinalizePackage(void);
+
+/*S
+     NEP - Abstract SLEPc object that manages all solvers for
+     nonlinear eigenvalue problems.
+
+   Level: beginner
+
+.seealso:  NEPCreate()
+S*/
+typedef struct _p_NEP* NEP;
+
+/*J
+    NEPType - String with the name of a nonlinear eigensolver
+
+   Level: beginner
+
+.seealso: NEPSetType(), NEP
+J*/
+typedef const char* NEPType;
+#define NEPRII       "rii"
+#define NEPSLP       "slp"
+#define NEPNARNOLDI  "narnoldi"
+#define NEPCISS      "ciss"
+#define NEPINTERPOL  "interpol"
+#define NEPNLEIGS    "nleigs"
+
+/* Logging support */
+SLEPC_EXTERN PetscClassId NEP_CLASSID;
+
+/*E
+    NEPProblemType - Determines the type of the nonlinear eigenproblem
+
+    Level: intermediate
+
+.seealso: NEPSetProblemType(), NEPGetProblemType()
+E*/
+typedef enum { NEP_GENERAL=1,
+               NEP_RATIONAL     /* NEP defined in split form with all f_i rational */
+             } NEPProblemType;
+
+/*E
+    NEPWhich - Determines which part of the spectrum is requested
+
+    Level: intermediate
+
+.seealso: NEPSetWhichEigenpairs(), NEPGetWhichEigenpairs()
+E*/
+typedef enum { NEP_LARGEST_MAGNITUDE=1,
+               NEP_SMALLEST_MAGNITUDE,
+               NEP_LARGEST_REAL,
+               NEP_SMALLEST_REAL,
+               NEP_LARGEST_IMAGINARY,
+               NEP_SMALLEST_IMAGINARY,
+               NEP_TARGET_MAGNITUDE,
+               NEP_TARGET_REAL,
+               NEP_TARGET_IMAGINARY,
+               NEP_ALL,
+               NEP_WHICH_USER } NEPWhich;
+
+/*E
+    NEPErrorType - The error type used to assess accuracy of computed solutions
+
+    Level: intermediate
+
+.seealso: NEPComputeError()
+E*/
+typedef enum { NEP_ERROR_ABSOLUTE,
+               NEP_ERROR_RELATIVE,
+               NEP_ERROR_BACKWARD } NEPErrorType;
+SLEPC_EXTERN const char *NEPErrorTypes[];
+
+/*E
+    NEPRefine - The refinement type
+
+    Level: intermediate
+
+.seealso: NEPSetRefine()
+E*/
+typedef enum { NEP_REFINE_NONE,
+               NEP_REFINE_SIMPLE,
+               NEP_REFINE_MULTIPLE } NEPRefine;
+SLEPC_EXTERN const char *NEPRefineTypes[];
+
+/*E
+    NEPRefineScheme - The scheme used for solving linear systems during iterative refinement
+
+    Level: intermediate
+
+.seealso: NEPSetRefine()
+E*/
+typedef enum { NEP_REFINE_SCHEME_SCHUR=1,
+               NEP_REFINE_SCHEME_MBE,
+               NEP_REFINE_SCHEME_EXPLICIT } NEPRefineScheme;
+SLEPC_EXTERN const char *NEPRefineSchemes[];
+
+/*E
+    NEPConv - Determines the convergence test
+
+    Level: intermediate
+
+.seealso: NEPSetConvergenceTest(), NEPSetConvergenceTestFunction()
+E*/
+typedef enum { NEP_CONV_ABS,
+               NEP_CONV_REL,
+               NEP_CONV_NORM,
+               NEP_CONV_USER } NEPConv;
+
+/*E
+    NEPStop - Determines the stopping test
+
+    Level: advanced
+
+.seealso: NEPSetStoppingTest(), NEPSetStoppingTestFunction()
+E*/
+typedef enum { NEP_STOP_BASIC,
+               NEP_STOP_USER } NEPStop;
+
+/*E
+    NEPConvergedReason - Reason a nonlinear eigensolver was said to
+         have converged or diverged
+
+    Level: intermediate
+
+.seealso: NEPSolve(), NEPGetConvergedReason(), NEPSetTolerances()
+E*/
+typedef enum {/* converged */
+              NEP_CONVERGED_TOL                =  1,
+              NEP_CONVERGED_USER               =  2,
+              /* diverged */
+              NEP_DIVERGED_ITS                 = -1,
+              NEP_DIVERGED_BREAKDOWN           = -2,
+                    /* unused                  = -3 */
+              NEP_DIVERGED_LINEAR_SOLVE        = -4,
+              NEP_DIVERGED_SUBSPACE_EXHAUSTED  = -5,
+              NEP_CONVERGED_ITERATING          =  0} NEPConvergedReason;
+SLEPC_EXTERN const char *const*NEPConvergedReasons;
+
+SLEPC_EXTERN PetscErrorCode NEPCreate(MPI_Comm,NEP*);
+SLEPC_EXTERN PetscErrorCode NEPDestroy(NEP*);
+SLEPC_EXTERN PetscErrorCode NEPReset(NEP);
+SLEPC_EXTERN PetscErrorCode NEPSetType(NEP,NEPType);
+SLEPC_EXTERN PetscErrorCode NEPGetType(NEP,NEPType*);
+SLEPC_EXTERN PetscErrorCode NEPSetProblemType(NEP,NEPProblemType);
+SLEPC_EXTERN PetscErrorCode NEPGetProblemType(NEP,NEPProblemType*);
+SLEPC_EXTERN PetscErrorCode NEPSetTarget(NEP,PetscScalar);
+SLEPC_EXTERN PetscErrorCode NEPGetTarget(NEP,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode NEPSetFromOptions(NEP);
+SLEPC_EXTERN PetscErrorCode NEPSetDSType(NEP);
+SLEPC_EXTERN PetscErrorCode NEPSetUp(NEP);
+SLEPC_EXTERN PetscErrorCode NEPSolve(NEP);
+SLEPC_EXTERN PetscErrorCode NEPView(NEP,PetscViewer);
+SLEPC_EXTERN PetscErrorCode NEPViewFromOptions(NEP,PetscObject,const char[]);
+SLEPC_EXTERN PetscErrorCode NEPErrorView(NEP,NEPErrorType,PetscViewer);
+SLEPC_EXTERN PetscErrorCode NEPErrorViewFromOptions(NEP);
+SLEPC_EXTERN PetscErrorCode NEPConvergedReasonView(NEP,PetscViewer);
+SLEPC_EXTERN PetscErrorCode NEPConvergedReasonViewFromOptions(NEP);
+PETSC_DEPRECATED_FUNCTION(3, 14, 0, "NEPConvergedReasonView()", ) static inline PetscErrorCode NEPReasonView(NEP nep,PetscViewer v) {return NEPConvergedReasonView(nep,v);}
+PETSC_DEPRECATED_FUNCTION(3, 14, 0, "NEPConvergedReasonViewFromOptions()", ) static inline PetscErrorCode NEPReasonViewFromOptions(NEP nep) {return NEPConvergedReasonViewFromOptions(nep);}
+SLEPC_EXTERN PetscErrorCode NEPValuesView(NEP,PetscViewer);
+SLEPC_EXTERN PetscErrorCode NEPValuesViewFromOptions(NEP);
+SLEPC_EXTERN PetscErrorCode NEPVectorsView(NEP,PetscViewer);
+SLEPC_EXTERN PetscErrorCode NEPVectorsViewFromOptions(NEP);
+
+/*S
+  NEPFunctionFn - A prototype of a NEP function evaluation function that would be passed to NEPSetFunction()
+
+  Calling Sequence:
++   nep    - eigensolver context obtained from NEPCreate()
+.   lambda - the scalar argument where T(.) must be evaluated
+.   T      - matrix that will contain T(lambda)
+.   P      - [optional] different matrix to build the preconditioner
+-   ctx    - [optional] user-defined context for private data for the
+             function evaluation routine (may be NULL)
+
+  Level: beginner
+
+.seealso: NEPSetFunction()
+S*/
+PETSC_EXTERN_TYPEDEF typedef PetscErrorCode(NEPFunctionFn)(NEP nep,PetscScalar lambda,Mat T,Mat P,void *ctx);
+
+/*S
+  NEPJacobianFn - A prototype of a NEP Jacobian evaluation function that would be passed to NEPSetJacobian()
+
+  Calling Sequence:
++   nep    - eigensolver context obtained from NEPCreate()
+.   lambda - the scalar argument where T'(.) must be evaluated
+.   J      - matrix that will contain T'(lambda)
+-   ctx    - [optional] user-defined context for private data for the
+             Jacobian evaluation routine (may be NULL)
+
+  Level: beginner
+
+.seealso: NEPSetJacobian()
+S*/
+PETSC_EXTERN_TYPEDEF typedef PetscErrorCode(NEPJacobianFn)(NEP nep,PetscScalar lambda,Mat J,void *ctx);
+
+SLEPC_EXTERN PetscErrorCode NEPSetFunction(NEP,Mat,Mat,NEPFunctionFn*,void*);
+SLEPC_EXTERN PetscErrorCode NEPGetFunction(NEP,Mat*,Mat*,NEPFunctionFn**,void**);
+SLEPC_EXTERN PetscErrorCode NEPSetJacobian(NEP,Mat,NEPJacobianFn*,void*);
+SLEPC_EXTERN PetscErrorCode NEPGetJacobian(NEP,Mat*,NEPJacobianFn**,void**);
+PETSC_DEPRECATED_FUNCTION(3, 12, 0, "NEPSetFunction() and NEPSetJacobian()", ) static inline PetscErrorCode NEPSetDerivatives(NEP nep,Mat A,PetscErrorCode (*fun)(NEP,PetscScalar,PetscInt,Mat,void*),void *ctx) {(void)A;(void)fun;(void)ctx;SETERRQ(PetscObjectComm((PetscObject)nep),PETSC_ERR_SUP,"Not implemented in this version");}
+PETSC_DEPRECATED_FUNCTION(3, 12, 0, "NEPGetFunction() and NEPGetJacobian()", ) static inline PetscErrorCode NEPGetDerivatives(NEP nep,Mat *A,PetscErrorCode (**fun)(NEP,PetscScalar,PetscInt,Mat,void*),void **ctx) {(void)A;(void)fun;(void)ctx;SETERRQ(PetscObjectComm((PetscObject)nep),PETSC_ERR_SUP,"Not implemented in this version");}
+SLEPC_EXTERN PetscErrorCode NEPSetSplitOperator(NEP,PetscInt,Mat[],FN[],MatStructure);
+SLEPC_EXTERN PetscErrorCode NEPGetSplitOperatorTerm(NEP,PetscInt,Mat*,FN*);
+SLEPC_EXTERN PetscErrorCode NEPGetSplitOperatorInfo(NEP,PetscInt*,MatStructure*);
+SLEPC_EXTERN PetscErrorCode NEPSetSplitPreconditioner(NEP,PetscInt,Mat[],MatStructure);
+SLEPC_EXTERN PetscErrorCode NEPGetSplitPreconditionerTerm(NEP,PetscInt,Mat*);
+SLEPC_EXTERN PetscErrorCode NEPGetSplitPreconditionerInfo(NEP,PetscInt*,MatStructure*);
+
+SLEPC_EXTERN PetscErrorCode NEPSetBV(NEP,BV);
+SLEPC_EXTERN PetscErrorCode NEPGetBV(NEP,BV*);
+SLEPC_EXTERN PetscErrorCode NEPSetRG(NEP,RG);
+SLEPC_EXTERN PetscErrorCode NEPGetRG(NEP,RG*);
+SLEPC_EXTERN PetscErrorCode NEPSetDS(NEP,DS);
+SLEPC_EXTERN PetscErrorCode NEPGetDS(NEP,DS*);
+SLEPC_EXTERN PetscErrorCode NEPRefineGetKSP(NEP,KSP*);
+SLEPC_EXTERN PetscErrorCode NEPSetTolerances(NEP,PetscReal,PetscInt);
+SLEPC_EXTERN PetscErrorCode NEPGetTolerances(NEP,PetscReal*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode NEPSetConvergenceTest(NEP,NEPConv);
+SLEPC_EXTERN PetscErrorCode NEPGetConvergenceTest(NEP,NEPConv*);
+SLEPC_EXTERN PetscErrorCode NEPConvergedAbsolute(NEP,PetscScalar,PetscScalar,PetscReal,PetscReal*,void*);
+SLEPC_EXTERN PetscErrorCode NEPConvergedRelative(NEP,PetscScalar,PetscScalar,PetscReal,PetscReal*,void*);
+SLEPC_EXTERN PetscErrorCode NEPConvergedNorm(NEP,PetscScalar,PetscScalar,PetscReal,PetscReal*,void*);
+SLEPC_EXTERN PetscErrorCode NEPSetStoppingTest(NEP,NEPStop);
+SLEPC_EXTERN PetscErrorCode NEPGetStoppingTest(NEP,NEPStop*);
+SLEPC_EXTERN PetscErrorCode NEPStoppingBasic(NEP,PetscInt,PetscInt,PetscInt,PetscInt,NEPConvergedReason*,void*);
+SLEPC_EXTERN PetscErrorCode NEPSetDimensions(NEP,PetscInt,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode NEPGetDimensions(NEP,PetscInt*,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode NEPSetRefine(NEP,NEPRefine,PetscInt,PetscReal,PetscInt,NEPRefineScheme);
+SLEPC_EXTERN PetscErrorCode NEPGetRefine(NEP,NEPRefine*,PetscInt*,PetscReal*,PetscInt*,NEPRefineScheme*);
+
+SLEPC_EXTERN PetscErrorCode NEPGetConverged(NEP,PetscInt*);
+SLEPC_EXTERN PetscErrorCode NEPGetEigenpair(NEP,PetscInt,PetscScalar*,PetscScalar*,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode NEPGetLeftEigenvector(NEP,PetscInt,Vec,Vec);
+
+SLEPC_EXTERN PetscErrorCode NEPComputeError(NEP,PetscInt,NEPErrorType,PetscReal*);
+PETSC_DEPRECATED_FUNCTION(3, 6, 0, "NEPComputeError()", ) static inline PetscErrorCode NEPComputeRelativeError(NEP nep,PetscInt i,PetscReal *r) {return NEPComputeError(nep,i,NEP_ERROR_RELATIVE,r);}
+PETSC_DEPRECATED_FUNCTION(3, 6, 0, "NEPComputeError() with NEP_ERROR_ABSOLUTE", ) static inline PetscErrorCode NEPComputeResidualNorm(NEP nep,PetscInt i,PetscReal *r) {return NEPComputeError(nep,i,NEP_ERROR_ABSOLUTE,r);}
+SLEPC_EXTERN PetscErrorCode NEPGetErrorEstimate(NEP,PetscInt,PetscReal*);
+
+SLEPC_EXTERN PetscErrorCode NEPComputeFunction(NEP,PetscScalar,Mat,Mat);
+SLEPC_EXTERN PetscErrorCode NEPComputeJacobian(NEP,PetscScalar,Mat);
+SLEPC_EXTERN PetscErrorCode NEPApplyFunction(NEP,PetscScalar,Vec,Vec,Vec,Mat,Mat);
+SLEPC_EXTERN PetscErrorCode NEPApplyAdjoint(NEP,PetscScalar,Vec,Vec,Vec,Mat,Mat);
+SLEPC_EXTERN PetscErrorCode NEPApplyJacobian(NEP,PetscScalar,Vec,Vec,Vec,Mat);
+SLEPC_EXTERN PetscErrorCode NEPProjectOperator(NEP,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode NEPGetIterationNumber(NEP,PetscInt*);
+
+SLEPC_EXTERN PetscErrorCode NEPSetInitialSpace(NEP,PetscInt,Vec[]);
+SLEPC_EXTERN PetscErrorCode NEPSetWhichEigenpairs(NEP,NEPWhich);
+SLEPC_EXTERN PetscErrorCode NEPGetWhichEigenpairs(NEP,NEPWhich*);
+SLEPC_EXTERN PetscErrorCode NEPSetTwoSided(NEP,PetscBool);
+SLEPC_EXTERN PetscErrorCode NEPGetTwoSided(NEP,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode NEPApplyResolvent(NEP,RG,PetscScalar,Vec,Vec);
+
+SLEPC_EXTERN PetscErrorCode NEPSetTrackAll(NEP,PetscBool);
+SLEPC_EXTERN PetscErrorCode NEPGetTrackAll(NEP,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode NEPGetConvergedReason(NEP,NEPConvergedReason*);
+
+SLEPC_EXTERN PetscErrorCode NEPMonitor(NEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt);
+SLEPC_EXTERN PetscErrorCode NEPMonitorSet(NEP,PetscErrorCode (*)(NEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,void*),void*,PetscErrorCode (*)(void**));
+SLEPC_EXTERN PetscErrorCode NEPMonitorCancel(NEP);
+SLEPC_EXTERN PetscErrorCode NEPGetMonitorContext(NEP,void*);
+
+SLEPC_EXTERN PetscErrorCode NEPMonitorSetFromOptions(NEP,const char[],const char[],void*,PetscBool);
+SLEPC_EXTERN PetscErrorCode NEPMonitorLGCreate(MPI_Comm,const char[],const char[],const char[],PetscInt,const char*[],int,int,int,int,PetscDrawLG*);
+SLEPC_EXTERN PetscErrorCode NEPMonitorFirst(NEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode NEPMonitorFirstDrawLG(NEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode NEPMonitorFirstDrawLGCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode NEPMonitorAll(NEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode NEPMonitorAllDrawLG(NEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode NEPMonitorAllDrawLGCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode NEPMonitorConverged(NEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode NEPMonitorConvergedCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode NEPMonitorConvergedDrawLG(NEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode NEPMonitorConvergedDrawLGCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode NEPMonitorConvergedDestroy(PetscViewerAndFormat**);
+
+SLEPC_EXTERN PetscErrorCode NEPSetOptionsPrefix(NEP,const char*);
+SLEPC_EXTERN PetscErrorCode NEPAppendOptionsPrefix(NEP,const char*);
+SLEPC_EXTERN PetscErrorCode NEPGetOptionsPrefix(NEP,const char*[]);
+
+SLEPC_EXTERN PetscFunctionList NEPList;
+SLEPC_EXTERN PetscFunctionList NEPMonitorList;
+SLEPC_EXTERN PetscFunctionList NEPMonitorCreateList;
+SLEPC_EXTERN PetscFunctionList NEPMonitorDestroyList;
+SLEPC_EXTERN PetscErrorCode NEPRegister(const char[],PetscErrorCode(*)(NEP));
+SLEPC_EXTERN PetscErrorCode NEPMonitorRegister(const char[],PetscViewerType,PetscViewerFormat,PetscErrorCode(*)(NEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*),PetscErrorCode(*)(PetscViewer,PetscViewerFormat,void*,PetscViewerAndFormat**),PetscErrorCode(*)(PetscViewerAndFormat**));
+
+SLEPC_EXTERN PetscErrorCode NEPSetWorkVecs(NEP,PetscInt);
+SLEPC_EXTERN PetscErrorCode NEPAllocateSolution(NEP,PetscInt);
+
+/*S
+  NEPConvergenceTestFn - A prototype of a NEP convergence test function that would be passed to NEPSetConvergenceTestFunction()
+
+  Calling Sequence:
++   nep    - eigensolver context obtained from NEPCreate()
+.   eigr   - real part of the eigenvalue
+.   eigi   - imaginary part of the eigenvalue
+.   res    - residual norm associated to the eigenpair
+.   errest - [output] computed error estimate
+-   ctx    - [optional] user-defined context for private data for the
+             convergence test routine (may be NULL)
+
+  Level: advanced
+
+.seealso: NEPSetConvergenceTestFunction()
+S*/
+PETSC_EXTERN_TYPEDEF typedef PetscErrorCode(NEPConvergenceTestFn)(NEP nep,PetscScalar eigr,PetscScalar eigi,PetscReal res,PetscReal *errest,void *ctx);
+
+/*S
+  NEPStoppingTestFn - A prototype of a NEP stopping test function that would be passed to NEPSetStoppingTestFunction()
+
+  Calling Sequence:
++   nep    - eigensolver context obtained from NEPCreate()
+.   its    - current number of iterations
+.   max_it - maximum number of iterations
+.   nconv  - number of currently converged eigenpairs
+.   nev    - number of requested eigenpairs
+.   reason - [output] result of the stopping test
+-   ctx    - [optional] user-defined context for private data for the
+             stopping test routine (may be NULL)
+
+  Level: advanced
+
+.seealso: NEPSetStoppingTestFunction()
+S*/
+PETSC_EXTERN_TYPEDEF typedef PetscErrorCode(NEPStoppingTestFn)(NEP nep,PetscInt its,PetscInt max_it,PetscInt nconv,PetscInt nev,NEPConvergedReason *reason,void *ctx);
+
+SLEPC_EXTERN PetscErrorCode NEPSetConvergenceTestFunction(NEP,NEPConvergenceTestFn*,void*,PetscErrorCode (*)(void*));
+SLEPC_EXTERN PetscErrorCode NEPSetStoppingTestFunction(NEP,NEPStoppingTestFn*,void*,PetscErrorCode (*)(void*));
+SLEPC_EXTERN PetscErrorCode NEPSetEigenvalueComparison(NEP,SlepcEigenvalueComparisonFn*,void*);
+
+/* --------- options specific to particular eigensolvers -------- */
+
+SLEPC_EXTERN PetscErrorCode NEPRIISetMaximumIterations(NEP,PetscInt);
+SLEPC_EXTERN PetscErrorCode NEPRIIGetMaximumIterations(NEP,PetscInt*);
+SLEPC_EXTERN PetscErrorCode NEPRIISetLagPreconditioner(NEP,PetscInt);
+SLEPC_EXTERN PetscErrorCode NEPRIIGetLagPreconditioner(NEP,PetscInt*);
+SLEPC_EXTERN PetscErrorCode NEPRIISetConstCorrectionTol(NEP,PetscBool);
+SLEPC_EXTERN PetscErrorCode NEPRIIGetConstCorrectionTol(NEP,PetscBool*);
+SLEPC_EXTERN PetscErrorCode NEPRIISetHermitian(NEP,PetscBool);
+SLEPC_EXTERN PetscErrorCode NEPRIIGetHermitian(NEP,PetscBool*);
+SLEPC_EXTERN PetscErrorCode NEPRIISetDeflationThreshold(NEP,PetscReal);
+SLEPC_EXTERN PetscErrorCode NEPRIIGetDeflationThreshold(NEP,PetscReal*);
+SLEPC_EXTERN PetscErrorCode NEPRIISetKSP(NEP,KSP);
+SLEPC_EXTERN PetscErrorCode NEPRIIGetKSP(NEP,KSP*);
+
+SLEPC_EXTERN PetscErrorCode NEPSLPSetDeflationThreshold(NEP,PetscReal);
+SLEPC_EXTERN PetscErrorCode NEPSLPGetDeflationThreshold(NEP,PetscReal*);
+SLEPC_EXTERN PetscErrorCode NEPSLPSetEPS(NEP,EPS);
+SLEPC_EXTERN PetscErrorCode NEPSLPGetEPS(NEP,EPS*);
+SLEPC_EXTERN PetscErrorCode NEPSLPSetEPSLeft(NEP,EPS);
+SLEPC_EXTERN PetscErrorCode NEPSLPGetEPSLeft(NEP,EPS*);
+SLEPC_EXTERN PetscErrorCode NEPSLPSetKSP(NEP,KSP);
+SLEPC_EXTERN PetscErrorCode NEPSLPGetKSP(NEP,KSP*);
+
+SLEPC_EXTERN PetscErrorCode NEPNArnoldiSetKSP(NEP,KSP);
+SLEPC_EXTERN PetscErrorCode NEPNArnoldiGetKSP(NEP,KSP*);
+SLEPC_EXTERN PetscErrorCode NEPNArnoldiSetLagPreconditioner(NEP,PetscInt);
+SLEPC_EXTERN PetscErrorCode NEPNArnoldiGetLagPreconditioner(NEP,PetscInt*);
+
+/*E
+    NEPCISSExtraction - determines the extraction technique in the CISS solver
+
+    Level: advanced
+
+.seealso: NEPCISSSetExtraction(), NEPCISSGetExtraction()
+E*/
+typedef enum { NEP_CISS_EXTRACTION_RITZ,
+               NEP_CISS_EXTRACTION_HANKEL,
+               NEP_CISS_EXTRACTION_CAA    } NEPCISSExtraction;
+SLEPC_EXTERN const char *NEPCISSExtractions[];
+
+#if defined(PETSC_USE_COMPLEX) || defined(PETSC_CLANG_STATIC_ANALYZER)
+SLEPC_EXTERN PetscErrorCode NEPCISSSetExtraction(NEP,NEPCISSExtraction);
+SLEPC_EXTERN PetscErrorCode NEPCISSGetExtraction(NEP,NEPCISSExtraction*);
+SLEPC_EXTERN PetscErrorCode NEPCISSSetSizes(NEP,PetscInt,PetscInt,PetscInt,PetscInt,PetscInt,PetscBool);
+SLEPC_EXTERN PetscErrorCode NEPCISSGetSizes(NEP,PetscInt*,PetscInt*,PetscInt*,PetscInt*,PetscInt*,PetscBool*);
+SLEPC_EXTERN PetscErrorCode NEPCISSSetThreshold(NEP,PetscReal,PetscReal);
+SLEPC_EXTERN PetscErrorCode NEPCISSGetThreshold(NEP,PetscReal*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode NEPCISSSetRefinement(NEP,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode NEPCISSGetRefinement(NEP,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode NEPCISSGetKSPs(NEP,PetscInt*,KSP**);
+#else
+#define SlepcNEPCISSUnavailable(nep) do { \
+    PetscFunctionBegin; \
+    SETERRQ(PetscObjectComm((PetscObject)nep),PETSC_ERR_SUP,"%s() not available with real scalars",PETSC_FUNCTION_NAME); \
+    } while (0)
+static inline PetscErrorCode NEPCISSSetExtraction(NEP nep,PETSC_UNUSED NEPCISSExtraction ex) {SlepcNEPCISSUnavailable(nep);}
+static inline PetscErrorCode NEPCISSGetExtraction(NEP nep,PETSC_UNUSED NEPCISSExtraction *ex) {SlepcNEPCISSUnavailable(nep);}
+static inline PetscErrorCode NEPCISSSetSizes(NEP nep,PETSC_UNUSED PetscInt ip,PETSC_UNUSED PetscInt bs,PETSC_UNUSED PetscInt ms,PETSC_UNUSED PetscInt npart,PETSC_UNUSED PetscInt bsmax,PETSC_UNUSED PetscBool realmats) {SlepcNEPCISSUnavailable(nep);}
+static inline PetscErrorCode NEPCISSGetSizes(NEP nep,PETSC_UNUSED PetscInt *ip,PETSC_UNUSED PetscInt *bs,PETSC_UNUSED PetscInt *ms,PETSC_UNUSED PetscInt *npart,PETSC_UNUSED PetscInt *bsmak,PETSC_UNUSED PetscBool *realmats) {SlepcNEPCISSUnavailable(nep);}
+static inline PetscErrorCode NEPCISSSetThreshold(NEP nep,PETSC_UNUSED PetscReal delta,PETSC_UNUSED PetscReal spur) {SlepcNEPCISSUnavailable(nep);}
+static inline PetscErrorCode NEPCISSGetThreshold(NEP nep,PETSC_UNUSED PetscReal *delta,PETSC_UNUSED PetscReal *spur) {SlepcNEPCISSUnavailable(nep);}
+static inline PetscErrorCode NEPCISSSetRefinement(NEP nep,PETSC_UNUSED PetscInt inner,PETSC_UNUSED PetscInt blsize) {SlepcNEPCISSUnavailable(nep);}
+static inline PetscErrorCode NEPCISSGetRefinement(NEP nep,PETSC_UNUSED PetscInt *inner,PETSC_UNUSED PetscInt *blsize) {SlepcNEPCISSUnavailable(nep);}
+static inline PetscErrorCode NEPCISSGetKSPs(NEP nep,PETSC_UNUSED PetscInt *nsolve,PETSC_UNUSED KSP **ksp) {SlepcNEPCISSUnavailable(nep);}
+#undef SlepcNEPCISSUnavailable
+#endif
+
+SLEPC_EXTERN PetscErrorCode NEPInterpolSetPEP(NEP,PEP);
+SLEPC_EXTERN PetscErrorCode NEPInterpolGetPEP(NEP,PEP*);
+SLEPC_EXTERN PetscErrorCode NEPInterpolSetInterpolation(NEP,PetscReal,PetscInt);
+SLEPC_EXTERN PetscErrorCode NEPInterpolGetInterpolation(NEP,PetscReal*,PetscInt*);
+
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSSetSingularitiesFunction(NEP,PetscErrorCode (*)(NEP,PetscInt*,PetscScalar*,void*),void*);
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSGetSingularitiesFunction(NEP,PetscErrorCode (**)(NEP,PetscInt*,PetscScalar*,void*),void**);
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSSetRestart(NEP,PetscReal);
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSGetRestart(NEP,PetscReal*);
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSSetLocking(NEP,PetscBool);
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSGetLocking(NEP,PetscBool*);
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSSetInterpolation(NEP,PetscReal,PetscInt);
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSGetInterpolation(NEP,PetscReal*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSSetRKShifts(NEP,PetscInt,PetscScalar[]);
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSGetRKShifts(NEP,PetscInt*,PetscScalar*[]);
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSGetKSPs(NEP,PetscInt*,KSP**);
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSSetFullBasis(NEP,PetscBool);
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSGetFullBasis(NEP,PetscBool*);
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSSetEPS(NEP,EPS);
+SLEPC_EXTERN PetscErrorCode NEPNLEIGSGetEPS(NEP,EPS*);

--- a/3rd/slepc/linux/include/slepcpep.h
+++ b/3rd/slepc/linux/include/slepcpep.h
@@ -1,0 +1,447 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   User interface for SLEPc's polynomial eigenvalue solvers
+*/
+
+#pragma once
+
+#include <slepceps.h>
+
+/* SUBMANSEC = PEP */
+
+SLEPC_EXTERN PetscErrorCode PEPInitializePackage(void);
+SLEPC_EXTERN PetscErrorCode PEPFinalizePackage(void);
+
+/*S
+     PEP - Abstract SLEPc object that manages all the polynomial eigenvalue
+     problem solvers.
+
+   Level: beginner
+
+.seealso:  PEPCreate()
+S*/
+typedef struct _p_PEP* PEP;
+
+/*J
+    PEPType - String with the name of a polynomial eigensolver
+
+   Level: beginner
+
+.seealso: PEPSetType(), PEP
+J*/
+typedef const char* PEPType;
+#define PEPLINEAR    "linear"
+#define PEPQARNOLDI  "qarnoldi"
+#define PEPTOAR      "toar"
+#define PEPSTOAR     "stoar"
+#define PEPJD        "jd"
+#define PEPCISS      "ciss"
+
+/* Logging support */
+SLEPC_EXTERN PetscClassId PEP_CLASSID;
+
+/*E
+    PEPProblemType - Determines the type of the polynomial eigenproblem
+
+    Level: intermediate
+
+.seealso: PEPSetProblemType(), PEPGetProblemType()
+E*/
+typedef enum { PEP_GENERAL=1,
+               PEP_HERMITIAN,   /* All A_i  Hermitian */
+               PEP_HYPERBOLIC,  /* QEP with Hermitian matrices, M>0, (x'Cx)^2 > 4(x'Mx)(x'Kx) */
+               PEP_GYROSCOPIC   /* QEP with M, K  Hermitian, M>0, C skew-Hermitian */
+             } PEPProblemType;
+
+/*E
+    PEPWhich - Determines which part of the spectrum is requested
+
+    Level: intermediate
+
+.seealso: PEPSetWhichEigenpairs(), PEPGetWhichEigenpairs()
+E*/
+typedef enum { PEP_LARGEST_MAGNITUDE=1,
+               PEP_SMALLEST_MAGNITUDE,
+               PEP_LARGEST_REAL,
+               PEP_SMALLEST_REAL,
+               PEP_LARGEST_IMAGINARY,
+               PEP_SMALLEST_IMAGINARY,
+               PEP_TARGET_MAGNITUDE,
+               PEP_TARGET_REAL,
+               PEP_TARGET_IMAGINARY,
+               PEP_ALL,
+               PEP_WHICH_USER } PEPWhich;
+
+/*E
+    PEPBasis - The type of polynomial basis used to represent the polynomial
+    eigenproblem
+
+    Level: intermediate
+
+.seealso: PEPSetBasis()
+E*/
+typedef enum { PEP_BASIS_MONOMIAL,
+               PEP_BASIS_CHEBYSHEV1,
+               PEP_BASIS_CHEBYSHEV2,
+               PEP_BASIS_LEGENDRE,
+               PEP_BASIS_LAGUERRE,
+               PEP_BASIS_HERMITE } PEPBasis;
+SLEPC_EXTERN const char *PEPBasisTypes[];
+
+/*E
+    PEPScale - The scaling strategy
+
+    Level: intermediate
+
+.seealso: PEPSetScale()
+E*/
+typedef enum { PEP_SCALE_NONE,
+               PEP_SCALE_SCALAR,
+               PEP_SCALE_DIAGONAL,
+               PEP_SCALE_BOTH } PEPScale;
+SLEPC_EXTERN const char *PEPScaleTypes[];
+
+/*E
+    PEPRefine - The refinement type
+
+    Level: intermediate
+
+.seealso: PEPSetRefine()
+E*/
+typedef enum { PEP_REFINE_NONE,
+               PEP_REFINE_SIMPLE,
+               PEP_REFINE_MULTIPLE } PEPRefine;
+SLEPC_EXTERN const char *PEPRefineTypes[];
+
+/*E
+    PEPRefineScheme - The scheme used for solving linear systems during iterative refinement
+
+    Level: intermediate
+
+.seealso: PEPSetRefine()
+E*/
+typedef enum { PEP_REFINE_SCHEME_SCHUR=1,
+               PEP_REFINE_SCHEME_MBE,
+               PEP_REFINE_SCHEME_EXPLICIT } PEPRefineScheme;
+SLEPC_EXTERN const char *PEPRefineSchemes[];
+
+/*E
+    PEPExtract - The extraction type
+
+    Level: intermediate
+
+.seealso: PEPSetExtract()
+E*/
+typedef enum { PEP_EXTRACT_NONE=1,
+               PEP_EXTRACT_NORM,
+               PEP_EXTRACT_RESIDUAL,
+               PEP_EXTRACT_STRUCTURED } PEPExtract;
+SLEPC_EXTERN const char *PEPExtractTypes[];
+
+/*E
+    PEPErrorType - The error type used to assess accuracy of computed solutions
+
+    Level: intermediate
+
+.seealso: PEPComputeError()
+E*/
+typedef enum { PEP_ERROR_ABSOLUTE,
+               PEP_ERROR_RELATIVE,
+               PEP_ERROR_BACKWARD } PEPErrorType;
+SLEPC_EXTERN const char *PEPErrorTypes[];
+
+/*E
+    PEPConv - Determines the convergence test
+
+    Level: intermediate
+
+.seealso: PEPSetConvergenceTest(), PEPSetConvergenceTestFunction()
+E*/
+typedef enum { PEP_CONV_ABS,
+               PEP_CONV_REL,
+               PEP_CONV_NORM,
+               PEP_CONV_USER } PEPConv;
+
+/*E
+    PEPStop - Determines the stopping test
+
+    Level: advanced
+
+.seealso: PEPSetStoppingTest(), PEPSetStoppingTestFunction()
+E*/
+typedef enum { PEP_STOP_BASIC,
+               PEP_STOP_USER } PEPStop;
+
+/*E
+    PEPConvergedReason - Reason an eigensolver was said to
+         have converged or diverged
+
+    Level: intermediate
+
+.seealso: PEPSolve(), PEPGetConvergedReason(), PEPSetTolerances()
+E*/
+typedef enum {/* converged */
+              PEP_CONVERGED_TOL                =  1,
+              PEP_CONVERGED_USER               =  2,
+              /* diverged */
+              PEP_DIVERGED_ITS                 = -1,
+              PEP_DIVERGED_BREAKDOWN           = -2,
+              PEP_DIVERGED_SYMMETRY_LOST       = -3,
+              PEP_CONVERGED_ITERATING          =  0} PEPConvergedReason;
+SLEPC_EXTERN const char *const*PEPConvergedReasons;
+
+SLEPC_EXTERN PetscErrorCode PEPCreate(MPI_Comm,PEP*);
+SLEPC_EXTERN PetscErrorCode PEPDestroy(PEP*);
+SLEPC_EXTERN PetscErrorCode PEPReset(PEP);
+SLEPC_EXTERN PetscErrorCode PEPSetType(PEP,PEPType);
+SLEPC_EXTERN PetscErrorCode PEPGetType(PEP,PEPType*);
+SLEPC_EXTERN PetscErrorCode PEPSetProblemType(PEP,PEPProblemType);
+SLEPC_EXTERN PetscErrorCode PEPGetProblemType(PEP,PEPProblemType*);
+SLEPC_EXTERN PetscErrorCode PEPSetOperators(PEP,PetscInt,Mat[]);
+SLEPC_EXTERN PetscErrorCode PEPGetOperators(PEP,PetscInt,Mat*);
+SLEPC_EXTERN PetscErrorCode PEPGetNumMatrices(PEP,PetscInt*);
+SLEPC_EXTERN PetscErrorCode PEPSetTarget(PEP,PetscScalar);
+SLEPC_EXTERN PetscErrorCode PEPGetTarget(PEP,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode PEPSetInterval(PEP,PetscReal,PetscReal);
+SLEPC_EXTERN PetscErrorCode PEPGetInterval(PEP,PetscReal*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode PEPSetFromOptions(PEP);
+SLEPC_EXTERN PetscErrorCode PEPSetDSType(PEP);
+SLEPC_EXTERN PetscErrorCode PEPSetUp(PEP);
+SLEPC_EXTERN PetscErrorCode PEPSolve(PEP);
+SLEPC_EXTERN PetscErrorCode PEPView(PEP,PetscViewer);
+SLEPC_EXTERN PetscErrorCode PEPViewFromOptions(PEP,PetscObject,const char[]);
+SLEPC_EXTERN PetscErrorCode PEPErrorView(PEP,PEPErrorType,PetscViewer);
+PETSC_DEPRECATED_FUNCTION(3, 6, 0, "PEPErrorView()", ) static inline PetscErrorCode PEPPrintSolution(PEP pep,PetscViewer v) {return PEPErrorView(pep,PEP_ERROR_BACKWARD,v);}
+SLEPC_EXTERN PetscErrorCode PEPErrorViewFromOptions(PEP);
+SLEPC_EXTERN PetscErrorCode PEPConvergedReasonView(PEP,PetscViewer);
+SLEPC_EXTERN PetscErrorCode PEPConvergedReasonViewFromOptions(PEP);
+PETSC_DEPRECATED_FUNCTION(3, 14, 0, "PEPConvergedReasonView()", ) static inline PetscErrorCode PEPReasonView(PEP pep,PetscViewer v) {return PEPConvergedReasonView(pep,v);}
+PETSC_DEPRECATED_FUNCTION(3, 14, 0, "PEPConvergedReasonViewFromOptions()", ) static inline PetscErrorCode PEPReasonViewFromOptions(PEP pep) {return PEPConvergedReasonViewFromOptions(pep);}
+SLEPC_EXTERN PetscErrorCode PEPValuesView(PEP,PetscViewer);
+SLEPC_EXTERN PetscErrorCode PEPValuesViewFromOptions(PEP);
+SLEPC_EXTERN PetscErrorCode PEPVectorsView(PEP,PetscViewer);
+SLEPC_EXTERN PetscErrorCode PEPVectorsViewFromOptions(PEP);
+SLEPC_EXTERN PetscErrorCode PEPSetBV(PEP,BV);
+SLEPC_EXTERN PetscErrorCode PEPGetBV(PEP,BV*);
+SLEPC_EXTERN PetscErrorCode PEPSetRG(PEP,RG);
+SLEPC_EXTERN PetscErrorCode PEPGetRG(PEP,RG*);
+SLEPC_EXTERN PetscErrorCode PEPSetDS(PEP,DS);
+SLEPC_EXTERN PetscErrorCode PEPGetDS(PEP,DS*);
+SLEPC_EXTERN PetscErrorCode PEPSetST(PEP,ST);
+SLEPC_EXTERN PetscErrorCode PEPGetST(PEP,ST*);
+SLEPC_EXTERN PetscErrorCode PEPRefineGetKSP(PEP,KSP*);
+
+SLEPC_EXTERN PetscErrorCode PEPSetTolerances(PEP,PetscReal,PetscInt);
+SLEPC_EXTERN PetscErrorCode PEPGetTolerances(PEP,PetscReal*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode PEPSetConvergenceTest(PEP,PEPConv);
+SLEPC_EXTERN PetscErrorCode PEPGetConvergenceTest(PEP,PEPConv*);
+SLEPC_EXTERN PetscErrorCode PEPConvergedAbsolute(PEP,PetscScalar,PetscScalar,PetscReal,PetscReal*,void*);
+SLEPC_EXTERN PetscErrorCode PEPConvergedRelative(PEP,PetscScalar,PetscScalar,PetscReal,PetscReal*,void*);
+SLEPC_EXTERN PetscErrorCode PEPConvergedNorm(PEP,PetscScalar,PetscScalar,PetscReal,PetscReal*,void*);
+SLEPC_EXTERN PetscErrorCode PEPSetStoppingTest(PEP,PEPStop);
+SLEPC_EXTERN PetscErrorCode PEPGetStoppingTest(PEP,PEPStop*);
+SLEPC_EXTERN PetscErrorCode PEPStoppingBasic(PEP,PetscInt,PetscInt,PetscInt,PetscInt,PEPConvergedReason*,void*);
+SLEPC_EXTERN PetscErrorCode PEPGetConvergedReason(PEP,PEPConvergedReason*);
+
+SLEPC_EXTERN PetscErrorCode PEPSetDimensions(PEP,PetscInt,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode PEPGetDimensions(PEP,PetscInt*,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode PEPSetScale(PEP,PEPScale,PetscReal,Vec,Vec,PetscInt,PetscReal);
+SLEPC_EXTERN PetscErrorCode PEPGetScale(PEP,PEPScale*,PetscReal*,Vec*,Vec*,PetscInt*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode PEPSetRefine(PEP,PEPRefine,PetscInt,PetscReal,PetscInt,PEPRefineScheme);
+SLEPC_EXTERN PetscErrorCode PEPGetRefine(PEP,PEPRefine*,PetscInt*,PetscReal*,PetscInt*,PEPRefineScheme*);
+SLEPC_EXTERN PetscErrorCode PEPSetExtract(PEP,PEPExtract);
+SLEPC_EXTERN PetscErrorCode PEPGetExtract(PEP,PEPExtract*);
+SLEPC_EXTERN PetscErrorCode PEPSetBasis(PEP,PEPBasis);
+SLEPC_EXTERN PetscErrorCode PEPGetBasis(PEP,PEPBasis*);
+
+SLEPC_EXTERN PetscErrorCode PEPGetConverged(PEP,PetscInt*);
+SLEPC_EXTERN PetscErrorCode PEPGetEigenpair(PEP,PetscInt,PetscScalar*,PetscScalar*,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode PEPComputeError(PEP,PetscInt,PEPErrorType,PetscReal*);
+PETSC_DEPRECATED_FUNCTION(3, 6, 0, "PEPComputeError()", ) static inline PetscErrorCode PEPComputeRelativeError(PEP pep,PetscInt i,PetscReal *r) {return PEPComputeError(pep,i,PEP_ERROR_BACKWARD,r);}
+PETSC_DEPRECATED_FUNCTION(3, 6, 0, "PEPComputeError() with PEP_ERROR_ABSOLUTE", ) static inline PetscErrorCode PEPComputeResidualNorm(PEP pep,PetscInt i,PetscReal *r) {return PEPComputeError(pep,i,PEP_ERROR_ABSOLUTE,r);}
+SLEPC_EXTERN PetscErrorCode PEPGetErrorEstimate(PEP,PetscInt,PetscReal*);
+SLEPC_EXTERN PetscErrorCode PEPGetIterationNumber(PEP,PetscInt*);
+
+SLEPC_EXTERN PetscErrorCode PEPSetInitialSpace(PEP,PetscInt,Vec[]);
+SLEPC_EXTERN PetscErrorCode PEPSetWhichEigenpairs(PEP,PEPWhich);
+SLEPC_EXTERN PetscErrorCode PEPGetWhichEigenpairs(PEP,PEPWhich*);
+
+SLEPC_EXTERN PetscErrorCode PEPSetTrackAll(PEP,PetscBool);
+SLEPC_EXTERN PetscErrorCode PEPGetTrackAll(PEP,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode PEPMonitor(PEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt);
+SLEPC_EXTERN PetscErrorCode PEPMonitorSet(PEP,PetscErrorCode (*)(PEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,void*),void*,PetscErrorCode (*)(void**));
+SLEPC_EXTERN PetscErrorCode PEPMonitorCancel(PEP);
+SLEPC_EXTERN PetscErrorCode PEPGetMonitorContext(PEP,void*);
+
+SLEPC_EXTERN PetscErrorCode PEPMonitorSetFromOptions(PEP,const char[],const char[],void*,PetscBool);
+SLEPC_EXTERN PetscErrorCode PEPMonitorLGCreate(MPI_Comm,const char[],const char[],const char[],PetscInt,const char*[],int,int,int,int,PetscDrawLG*);
+SLEPC_EXTERN PetscErrorCode PEPMonitorFirst(PEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode PEPMonitorFirstDrawLG(PEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode PEPMonitorFirstDrawLGCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode PEPMonitorAll(PEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode PEPMonitorAllDrawLG(PEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode PEPMonitorAllDrawLGCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode PEPMonitorConverged(PEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode PEPMonitorConvergedCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode PEPMonitorConvergedDrawLG(PEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode PEPMonitorConvergedDrawLGCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode PEPMonitorConvergedDestroy(PetscViewerAndFormat**);
+
+SLEPC_EXTERN PetscErrorCode PEPSetOptionsPrefix(PEP,const char*);
+SLEPC_EXTERN PetscErrorCode PEPAppendOptionsPrefix(PEP,const char*);
+SLEPC_EXTERN PetscErrorCode PEPGetOptionsPrefix(PEP,const char*[]);
+
+SLEPC_EXTERN PetscFunctionList PEPList;
+SLEPC_EXTERN PetscFunctionList PEPMonitorList;
+SLEPC_EXTERN PetscFunctionList PEPMonitorCreateList;
+SLEPC_EXTERN PetscFunctionList PEPMonitorDestroyList;
+SLEPC_EXTERN PetscErrorCode PEPRegister(const char[],PetscErrorCode(*)(PEP));
+SLEPC_EXTERN PetscErrorCode PEPMonitorRegister(const char[],PetscViewerType,PetscViewerFormat,PetscErrorCode(*)(PEP,PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscReal*,PetscInt,PetscViewerAndFormat*),PetscErrorCode(*)(PetscViewer,PetscViewerFormat,void*,PetscViewerAndFormat**),PetscErrorCode(*)(PetscViewerAndFormat**));
+
+SLEPC_EXTERN PetscErrorCode PEPSetWorkVecs(PEP,PetscInt);
+SLEPC_EXTERN PetscErrorCode PEPAllocateSolution(PEP,PetscInt);
+
+/*S
+  PEPConvergenceTestFn - A prototype of a PEP convergence test function that would be passed to PEPSetConvergenceTestFunction()
+
+  Calling Sequence:
++   pep    - eigensolver context obtained from PEPCreate()
+.   eigr   - real part of the eigenvalue
+.   eigi   - imaginary part of the eigenvalue
+.   res    - residual norm associated to the eigenpair
+.   errest - [output] computed error estimate
+-   ctx    - [optional] user-defined context for private data for the
+             convergence test routine (may be NULL)
+
+  Level: advanced
+
+.seealso: PEPSetConvergenceTestFunction()
+S*/
+PETSC_EXTERN_TYPEDEF typedef PetscErrorCode(PEPConvergenceTestFn)(PEP pep,PetscScalar eigr,PetscScalar eigi,PetscReal res,PetscReal *errest,void *ctx);
+
+/*S
+  PEPStoppingTestFn - A prototype of a PEP stopping test function that would be passed to PEPSetStoppingTestFunction()
+
+  Calling Sequence:
++   pep    - eigensolver context obtained from PEPCreate()
+.   its    - current number of iterations
+.   max_it - maximum number of iterations
+.   nconv  - number of currently converged eigenpairs
+.   nev    - number of requested eigenpairs
+.   reason - [output] result of the stopping test
+-   ctx    - [optional] user-defined context for private data for the
+             stopping test routine (may be NULL)
+
+  Level: advanced
+
+.seealso: PEPSetStoppingTestFunction()
+S*/
+PETSC_EXTERN_TYPEDEF typedef PetscErrorCode(PEPStoppingTestFn)(PEP pep,PetscInt its,PetscInt max_it,PetscInt nconv,PetscInt nev,PEPConvergedReason *reason,void *ctx);
+
+SLEPC_EXTERN PetscErrorCode PEPSetConvergenceTestFunction(PEP,PEPConvergenceTestFn*,void*,PetscErrorCode (*)(void*));
+SLEPC_EXTERN PetscErrorCode PEPSetStoppingTestFunction(PEP,PEPStoppingTestFn*,void*,PetscErrorCode (*)(void*));
+SLEPC_EXTERN PetscErrorCode PEPSetEigenvalueComparison(PEP,SlepcEigenvalueComparisonFn*,void*);
+
+/* --------- options specific to particular eigensolvers -------- */
+
+SLEPC_EXTERN PetscErrorCode PEPLinearSetLinearization(PEP,PetscReal,PetscReal);
+SLEPC_EXTERN PetscErrorCode PEPLinearGetLinearization(PEP,PetscReal*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode PEPLinearSetExplicitMatrix(PEP,PetscBool);
+SLEPC_EXTERN PetscErrorCode PEPLinearGetExplicitMatrix(PEP,PetscBool*);
+SLEPC_EXTERN PetscErrorCode PEPLinearSetEPS(PEP,EPS);
+SLEPC_EXTERN PetscErrorCode PEPLinearGetEPS(PEP,EPS*);
+PETSC_DEPRECATED_FUNCTION(3, 10, 0, "PEPLinearSetLinearization()", ) static inline PetscErrorCode PEPLinearSetCompanionForm(PEP pep,PetscInt cform) {return (cform==1)?PEPLinearSetLinearization(pep,1.0,0.0):PEPLinearSetLinearization(pep,0.0,1.0);}
+PETSC_DEPRECATED_FUNCTION(3, 10, 0, "PEPLinearGetLinearization()", ) static inline PetscErrorCode PEPLinearGetCompanionForm(PEP pep,PetscInt *cform) {(void)pep; if (cform) *cform=1; return PETSC_SUCCESS;}
+
+SLEPC_EXTERN PetscErrorCode PEPQArnoldiSetRestart(PEP,PetscReal);
+SLEPC_EXTERN PetscErrorCode PEPQArnoldiGetRestart(PEP,PetscReal*);
+SLEPC_EXTERN PetscErrorCode PEPQArnoldiSetLocking(PEP,PetscBool);
+SLEPC_EXTERN PetscErrorCode PEPQArnoldiGetLocking(PEP,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode PEPTOARSetRestart(PEP,PetscReal);
+SLEPC_EXTERN PetscErrorCode PEPTOARGetRestart(PEP,PetscReal*);
+SLEPC_EXTERN PetscErrorCode PEPTOARSetLocking(PEP,PetscBool);
+SLEPC_EXTERN PetscErrorCode PEPTOARGetLocking(PEP,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode PEPSTOARSetLinearization(PEP,PetscReal,PetscReal);
+SLEPC_EXTERN PetscErrorCode PEPSTOARGetLinearization(PEP,PetscReal*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode PEPSTOARSetLocking(PEP,PetscBool);
+SLEPC_EXTERN PetscErrorCode PEPSTOARGetLocking(PEP,PetscBool*);
+SLEPC_EXTERN PetscErrorCode PEPSTOARSetDetectZeros(PEP,PetscBool);
+SLEPC_EXTERN PetscErrorCode PEPSTOARGetDetectZeros(PEP,PetscBool*);
+SLEPC_EXTERN PetscErrorCode PEPSTOARGetInertias(PEP,PetscInt*,PetscReal**,PetscInt**);
+SLEPC_EXTERN PetscErrorCode PEPSTOARSetDimensions(PEP,PetscInt,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode PEPSTOARGetDimensions(PEP,PetscInt*,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode PEPSTOARSetCheckEigenvalueType(PEP,PetscBool);
+SLEPC_EXTERN PetscErrorCode PEPSTOARGetCheckEigenvalueType(PEP,PetscBool*);
+SLEPC_EXTERN PetscErrorCode PEPCheckDefiniteQEP(PEP,PetscReal*,PetscReal*,PetscInt*,PetscInt*);
+
+/*E
+    PEPJDProjection - The type of projection to be used in the Jacobi-Davidson solver
+
+    Level: intermediate
+
+.seealso: PEPJDSetProjection()
+E*/
+typedef enum { PEP_JD_PROJECTION_HARMONIC,
+               PEP_JD_PROJECTION_ORTHOGONAL } PEPJDProjection;
+SLEPC_EXTERN const char *PEPJDProjectionTypes[];
+
+SLEPC_EXTERN PetscErrorCode PEPJDSetRestart(PEP,PetscReal);
+SLEPC_EXTERN PetscErrorCode PEPJDGetRestart(PEP,PetscReal*);
+SLEPC_EXTERN PetscErrorCode PEPJDSetFix(PEP,PetscReal);
+SLEPC_EXTERN PetscErrorCode PEPJDGetFix(PEP,PetscReal*);
+SLEPC_EXTERN PetscErrorCode PEPJDSetReusePreconditioner(PEP,PetscBool);
+SLEPC_EXTERN PetscErrorCode PEPJDGetReusePreconditioner(PEP,PetscBool*);
+SLEPC_EXTERN PetscErrorCode PEPJDSetMinimalityIndex(PEP,PetscInt);
+SLEPC_EXTERN PetscErrorCode PEPJDGetMinimalityIndex(PEP,PetscInt*);
+SLEPC_EXTERN PetscErrorCode PEPJDSetProjection(PEP,PEPJDProjection);
+SLEPC_EXTERN PetscErrorCode PEPJDGetProjection(PEP,PEPJDProjection*);
+
+/*E
+    PEPCISSExtraction - determines the extraction technique in the CISS solver
+
+    Level: advanced
+
+.seealso: PEPCISSSetExtraction(), PEPCISSGetExtraction()
+E*/
+typedef enum { PEP_CISS_EXTRACTION_RITZ,
+               PEP_CISS_EXTRACTION_HANKEL,
+               PEP_CISS_EXTRACTION_CAA    } PEPCISSExtraction;
+SLEPC_EXTERN const char *PEPCISSExtractions[];
+
+#if defined(PETSC_USE_COMPLEX) || defined(PETSC_CLANG_STATIC_ANALYZER)
+SLEPC_EXTERN PetscErrorCode PEPCISSSetExtraction(PEP,PEPCISSExtraction);
+SLEPC_EXTERN PetscErrorCode PEPCISSGetExtraction(PEP,PEPCISSExtraction*);
+SLEPC_EXTERN PetscErrorCode PEPCISSSetSizes(PEP,PetscInt,PetscInt,PetscInt,PetscInt,PetscInt,PetscBool);
+SLEPC_EXTERN PetscErrorCode PEPCISSGetSizes(PEP,PetscInt*,PetscInt*,PetscInt*,PetscInt*,PetscInt*,PetscBool*);
+SLEPC_EXTERN PetscErrorCode PEPCISSSetThreshold(PEP,PetscReal,PetscReal);
+SLEPC_EXTERN PetscErrorCode PEPCISSGetThreshold(PEP,PetscReal*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode PEPCISSSetRefinement(PEP,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode PEPCISSGetRefinement(PEP,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode PEPCISSGetKSPs(PEP,PetscInt*,KSP**);
+#else
+#define SlepcPEPCISSUnavailable(pep) do { \
+    PetscFunctionBegin; \
+    SETERRQ(PetscObjectComm((PetscObject)pep),PETSC_ERR_SUP,"%s() not available with real scalars",PETSC_FUNCTION_NAME); \
+    } while (0)
+static inline PetscErrorCode PEPCISSSetExtraction(PEP pep,PETSC_UNUSED PEPCISSExtraction ex) {SlepcPEPCISSUnavailable(pep);}
+static inline PetscErrorCode PEPCISSGetExtraction(PEP pep,PETSC_UNUSED PEPCISSExtraction *ex) {SlepcPEPCISSUnavailable(pep);}
+static inline PetscErrorCode PEPCISSSetSizes(PEP pep,PETSC_UNUSED PetscInt ip,PETSC_UNUSED PetscInt bs,PETSC_UNUSED PetscInt ms,PETSC_UNUSED PetscInt npart,PETSC_UNUSED PetscInt bsmax,PETSC_UNUSED PetscBool realmats) {SlepcPEPCISSUnavailable(pep);}
+static inline PetscErrorCode PEPCISSGetSizes(PEP pep,PETSC_UNUSED PetscInt *ip,PETSC_UNUSED PetscInt *bs,PETSC_UNUSED PetscInt *ms,PETSC_UNUSED PetscInt *npart,PETSC_UNUSED PetscInt *bsmak,PETSC_UNUSED PetscBool *realmats) {SlepcPEPCISSUnavailable(pep);}
+static inline PetscErrorCode PEPCISSSetThreshold(PEP pep,PETSC_UNUSED PetscReal delta,PETSC_UNUSED PetscReal spur) {SlepcPEPCISSUnavailable(pep);}
+static inline PetscErrorCode PEPCISSGetThreshold(PEP pep,PETSC_UNUSED PetscReal *delta,PETSC_UNUSED PetscReal *spur) {SlepcPEPCISSUnavailable(pep);}
+static inline PetscErrorCode PEPCISSSetRefinement(PEP pep,PETSC_UNUSED PetscInt inner,PETSC_UNUSED PetscInt blsize) {SlepcPEPCISSUnavailable(pep);}
+static inline PetscErrorCode PEPCISSGetRefinement(PEP pep,PETSC_UNUSED PetscInt *inner,PETSC_UNUSED PetscInt *blsize) {SlepcPEPCISSUnavailable(pep);}
+static inline PetscErrorCode PEPCISSGetKSPs(PEP pep,PETSC_UNUSED PetscInt *nsolve,PETSC_UNUSED KSP **ksp) {SlepcPEPCISSUnavailable(pep);}
+#undef SlepcPEPCISSUnavailable
+#endif

--- a/3rd/slepc/linux/include/slepcrg.h
+++ b/3rd/slepc/linux/include/slepcrg.h
@@ -1,0 +1,90 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   User interface for the region object in SLEPc
+*/
+
+#pragma once
+
+#include <slepcsys.h>
+#include <slepcrgtypes.h>
+
+/* SUBMANSEC = RG */
+
+SLEPC_EXTERN PetscErrorCode RGInitializePackage(void);
+SLEPC_EXTERN PetscErrorCode RGFinalizePackage(void);
+
+/*J
+   RGType - String with the name of the region.
+
+   Level: beginner
+
+.seealso: RGSetType(), RG
+J*/
+typedef const char* RGType;
+#define RGINTERVAL  "interval"
+#define RGPOLYGON   "polygon"
+#define RGELLIPSE   "ellipse"
+#define RGRING      "ring"
+
+/* Logging support */
+SLEPC_EXTERN PetscClassId RG_CLASSID;
+
+SLEPC_EXTERN PetscErrorCode RGCreate(MPI_Comm,RG*);
+SLEPC_EXTERN PetscErrorCode RGSetType(RG,RGType);
+SLEPC_EXTERN PetscErrorCode RGGetType(RG,RGType*);
+SLEPC_EXTERN PetscErrorCode RGSetOptionsPrefix(RG,const char *);
+SLEPC_EXTERN PetscErrorCode RGAppendOptionsPrefix(RG,const char *);
+SLEPC_EXTERN PetscErrorCode RGGetOptionsPrefix(RG,const char *[]);
+SLEPC_EXTERN PetscErrorCode RGSetFromOptions(RG);
+SLEPC_EXTERN PetscErrorCode RGView(RG,PetscViewer);
+SLEPC_EXTERN PetscErrorCode RGViewFromOptions(RG,PetscObject,const char[]);
+SLEPC_EXTERN PetscErrorCode RGDestroy(RG*);
+
+/*E
+    RGQuadRule - determines how to compute the quadrature parameters
+
+    Level: advanced
+
+.seealso: RGComputeQuadrature()
+E*/
+typedef enum { RG_QUADRULE_TRAPEZOIDAL=1,
+               RG_QUADRULE_CHEBYSHEV } RGQuadRule;
+
+SLEPC_EXTERN PetscErrorCode RGIsTrivial(RG,PetscBool*);
+SLEPC_EXTERN PetscErrorCode RGSetComplement(RG,PetscBool);
+SLEPC_EXTERN PetscErrorCode RGGetComplement(RG,PetscBool*);
+SLEPC_EXTERN PetscErrorCode RGSetScale(RG,PetscReal);
+SLEPC_EXTERN PetscErrorCode RGGetScale(RG,PetscReal*);
+SLEPC_EXTERN PetscErrorCode RGPushScale(RG,PetscReal);
+SLEPC_EXTERN PetscErrorCode RGPopScale(RG);
+SLEPC_EXTERN PetscErrorCode RGCheckInside(RG,PetscInt,PetscScalar*,PetscScalar*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode RGIsAxisymmetric(RG,PetscBool,PetscBool*);
+SLEPC_EXTERN PetscErrorCode RGCanUseConjugates(RG,PetscBool,PetscBool*);
+SLEPC_EXTERN PetscErrorCode RGComputeContour(RG,PetscInt,PetscScalar*,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode RGComputeBoundingBox(RG,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode RGComputeQuadrature(RG,RGQuadRule,PetscInt,PetscScalar*,PetscScalar*,PetscScalar*);
+
+SLEPC_EXTERN PetscFunctionList RGList;
+SLEPC_EXTERN PetscErrorCode RGRegister(const char[],PetscErrorCode(*)(RG));
+
+/* --------- options specific to particular regions -------- */
+
+SLEPC_EXTERN PetscErrorCode RGEllipseSetParameters(RG,PetscScalar,PetscReal,PetscReal);
+SLEPC_EXTERN PetscErrorCode RGEllipseGetParameters(RG,PetscScalar*,PetscReal*,PetscReal*);
+
+SLEPC_EXTERN PetscErrorCode RGIntervalSetEndpoints(RG,PetscReal,PetscReal,PetscReal,PetscReal);
+SLEPC_EXTERN PetscErrorCode RGIntervalGetEndpoints(RG,PetscReal*,PetscReal*,PetscReal*,PetscReal*);
+
+SLEPC_EXTERN PetscErrorCode RGPolygonSetVertices(RG,PetscInt,PetscScalar*,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode RGPolygonGetVertices(RG,PetscInt*,PetscScalar**,PetscScalar**);
+
+SLEPC_EXTERN PetscErrorCode RGRingSetParameters(RG,PetscScalar,PetscReal,PetscReal,PetscReal,PetscReal,PetscReal);
+SLEPC_EXTERN PetscErrorCode RGRingGetParameters(RG,PetscScalar*,PetscReal*,PetscReal*,PetscReal*,PetscReal*,PetscReal*);

--- a/3rd/slepc/linux/include/slepcrgtypes.h
+++ b/3rd/slepc/linux/include/slepcrgtypes.h
@@ -1,0 +1,22 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#pragma once
+
+/* SUBMANSEC = RG */
+
+/*S
+   RG - Region of the complex plane.
+
+   Level: beginner
+
+.seealso: RGCreate()
+S*/
+typedef struct _p_RG* RG;

--- a/3rd/slepc/linux/include/slepcsc.h
+++ b/3rd/slepc/linux/include/slepcsc.h
@@ -1,0 +1,118 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   Sorting criterion for various solvers
+*/
+
+#pragma once
+
+#include <slepcsys.h>
+#include <slepcrgtypes.h>
+
+/* SUBMANSEC = sys */
+
+/*S
+  SlepcEigenvalueComparisonFn - A prototype of an eigenvalue comparison function that would be passed to EPSSetEigenvalueComparison() and analogue functions in other solver types
+
+  Calling Sequence:
++   ar     - real part of the 1st eigenvalue
+.   ai     - imaginary part of the 1st eigenvalue
+.   br     - real part of the 2nd eigenvalue
+.   bi     - imaginary part of the 2nd eigenvalue
+.   res    - [output] result of comparison
+-   ctx    - [optional] user-defined context for private data for the
+             eigenvalue comparison routine (may be NULL)
+
+  Level: advanced
+
+.seealso: EPSSetEigenvalueComparison()
+S*/
+PETSC_EXTERN_TYPEDEF typedef PetscErrorCode(SlepcEigenvalueComparisonFn)(PetscScalar ar,PetscScalar ai,PetscScalar br,PetscScalar bi,PetscInt *res,void *ctx);
+
+/*S
+  SlepcArbitrarySelectionFn - A prototype of an arbitrary selection function that would be passed to EPSSetArbitrarySelection() and analogue functions in other solver types
+
+  Calling Sequence:
++   er     - real part of the current eigenvalue approximation
+.   ei     - imaginary part of the current eigenvalue approximation
+.   xr     - real part of the current eigenvector approximation
+.   xi     - imaginary part of the current eigenvector approximation
+.   rr     - result of evaluation (real part)
+.   ri     - result of evaluation (imaginary part)
+-   ctx    - [optional] user-defined context for private data for the
+             arbitrary selection routine (may be NULL)
+
+  Level: advanced
+
+.seealso: EPSSetArbitrarySelection()
+S*/
+PETSC_EXTERN_TYPEDEF typedef PetscErrorCode(SlepcArbitrarySelectionFn)(PetscScalar er,PetscScalar ei,Vec xr,Vec xi,PetscScalar *rr,PetscScalar *ri,void *ctx);
+
+/*S
+    SlepcSC - Data structure (C struct) for storing information about
+        the sorting criterion used by different eigensolver objects.
+
+   Notes:
+   The SlepcSC structure contains a mapping function and a comparison
+   function (with associated contexts).
+   The mapping function usually calls ST's backtransform.
+   An optional region can also be used to give higher priority to values inside it.
+
+   The comparison function must have the following calling sequence
+
+$  comparison(PetscScalar ar,PetscScalar ai,PetscScalar br,PetscScalar bi,PetscInt *res,void *ctx)
+
++  ar  - real part of the 1st eigenvalue
+.  ai  - imaginary part of the 1st eigenvalue
+.  br  - real part of the 2nd eigenvalue
+.  bi  - imaginary part of the 2nd eigenvalue
+.  res - result of comparison
+-  ctx - optional context, stored in comparisonctx
+
+   The returning parameter 'res' can be
++  negative - if the 1st value is preferred to the 2st one
+.  zero     - if both values are equally preferred
+-  positive - if the 2st value is preferred to the 1st one
+
+   Fortran usage is not supported.
+
+   Level: developer
+
+.seealso: SlepcSCCompare()
+S*/
+struct _n_SlepcSC {
+  /* map values before sorting, typically a call to STBackTransform (mapctx=ST) */
+  PetscErrorCode (*map)(PetscObject,PetscInt,PetscScalar*,PetscScalar*);
+  PetscObject    mapobj;
+  /* comparison function such as SlepcCompareLargestMagnitude */
+  SlepcEigenvalueComparisonFn *comparison;
+  void           *comparisonctx;
+  /* optional region for filtering */
+  RG             rg;
+};
+typedef struct _n_SlepcSC* SlepcSC;
+
+SLEPC_EXTERN PetscErrorCode SlepcSCCompare(SlepcSC,PetscScalar,PetscScalar,PetscScalar,PetscScalar,PetscInt*);
+SLEPC_EXTERN PetscErrorCode SlepcSortEigenvalues(SlepcSC,PetscInt n,PetscScalar *eigr,PetscScalar *eigi,PetscInt *perm);
+
+SLEPC_EXTERN PetscErrorCode SlepcMap_ST(PetscObject,PetscInt,PetscScalar*,PetscScalar*);
+
+SLEPC_EXTERN PetscErrorCode SlepcCompareLargestMagnitude(PetscScalar,PetscScalar,PetscScalar,PetscScalar,PetscInt*,void*);
+SLEPC_EXTERN PetscErrorCode SlepcCompareSmallestMagnitude(PetscScalar,PetscScalar,PetscScalar,PetscScalar,PetscInt*,void*);
+SLEPC_EXTERN PetscErrorCode SlepcCompareLargestReal(PetscScalar,PetscScalar,PetscScalar,PetscScalar,PetscInt*,void*);
+SLEPC_EXTERN PetscErrorCode SlepcCompareSmallestReal(PetscScalar,PetscScalar,PetscScalar,PetscScalar,PetscInt*,void*);
+SLEPC_EXTERN PetscErrorCode SlepcCompareLargestImaginary(PetscScalar,PetscScalar,PetscScalar,PetscScalar,PetscInt*,void*);
+SLEPC_EXTERN PetscErrorCode SlepcCompareSmallestImaginary(PetscScalar,PetscScalar,PetscScalar,PetscScalar,PetscInt*,void*);
+SLEPC_EXTERN PetscErrorCode SlepcCompareTargetMagnitude(PetscScalar,PetscScalar,PetscScalar,PetscScalar,PetscInt*,void*);
+SLEPC_EXTERN PetscErrorCode SlepcCompareTargetReal(PetscScalar,PetscScalar,PetscScalar,PetscScalar,PetscInt*,void*);
+#if defined(PETSC_USE_COMPLEX)
+SLEPC_EXTERN PetscErrorCode SlepcCompareTargetImaginary(PetscScalar,PetscScalar,PetscScalar,PetscScalar,PetscInt*,void*);
+#endif
+SLEPC_EXTERN PetscErrorCode SlepcCompareSmallestPosReal(PetscScalar,PetscScalar,PetscScalar,PetscScalar,PetscInt*,void*);

--- a/3rd/slepc/linux/include/slepcst.h
+++ b/3rd/slepc/linux/include/slepcst.h
@@ -1,0 +1,177 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   Spectral transformation module for eigenvalue problems
+*/
+
+#pragma once
+
+#include <slepcsys.h>
+#include <slepcbv.h>
+#include <petscksp.h>
+
+/* SUBMANSEC = ST */
+
+SLEPC_EXTERN PetscErrorCode STInitializePackage(void);
+SLEPC_EXTERN PetscErrorCode STFinalizePackage(void);
+
+/*S
+    ST - Abstract SLEPc object that manages spectral transformations.
+    This object is accessed only in advanced applications.
+
+    Level: beginner
+
+.seealso:  STCreate(), EPS
+S*/
+typedef struct _p_ST* ST;
+
+/*J
+    STType - String with the name of a SLEPc spectral transformation
+
+    Level: beginner
+
+.seealso: STSetType(), ST
+J*/
+typedef const char* STType;
+#define STSHELL     "shell"
+#define STSHIFT     "shift"
+#define STSINVERT   "sinvert"
+#define STCAYLEY    "cayley"
+#define STPRECOND   "precond"
+#define STFILTER    "filter"
+
+/* Logging support */
+SLEPC_EXTERN PetscClassId ST_CLASSID;
+
+SLEPC_EXTERN PetscErrorCode STCreate(MPI_Comm,ST*);
+SLEPC_EXTERN PetscErrorCode STDestroy(ST*);
+SLEPC_EXTERN PetscErrorCode STReset(ST);
+SLEPC_EXTERN PetscErrorCode STSetType(ST,STType);
+SLEPC_EXTERN PetscErrorCode STGetType(ST,STType*);
+SLEPC_EXTERN PetscErrorCode STSetMatrices(ST,PetscInt,Mat*);
+SLEPC_EXTERN PetscErrorCode STGetMatrix(ST,PetscInt,Mat*);
+SLEPC_EXTERN PetscErrorCode STGetMatrixTransformed(ST,PetscInt,Mat*);
+SLEPC_EXTERN PetscErrorCode STGetNumMatrices(ST,PetscInt*);
+SLEPC_EXTERN PetscErrorCode STGetOperator(ST,Mat*);
+SLEPC_EXTERN PetscErrorCode STRestoreOperator(ST,Mat*);
+SLEPC_EXTERN PetscErrorCode STSetUp(ST);
+SLEPC_EXTERN PetscErrorCode STSetFromOptions(ST);
+SLEPC_EXTERN PetscErrorCode STView(ST,PetscViewer);
+SLEPC_EXTERN PetscErrorCode STViewFromOptions(ST,PetscObject,const char[]);
+
+PETSC_DEPRECATED_FUNCTION(3, 15, 0, "STSetMatrices()", ) static inline PetscErrorCode STSetOperators(ST st,PetscInt n,Mat *A) {return STSetMatrices(st,n,A);}
+PETSC_DEPRECATED_FUNCTION(3, 15, 0, "STGetMatrix()", ) static inline PetscErrorCode STGetOperators(ST st,PetscInt k,Mat *A) {return STGetMatrix(st,k,A);}
+PETSC_DEPRECATED_FUNCTION(3, 15, 0, "STGetMatrixTransformed()", ) static inline PetscErrorCode STGetTOperators(ST st,PetscInt k,Mat *A) {return STGetMatrixTransformed(st,k,A);}
+PETSC_DEPRECATED_FUNCTION(3, 15, 0, "STGetOperator() followed by MatComputeOperator()", ) static inline PetscErrorCode STComputeExplicitOperator(ST st,Mat *A)
+{
+  Mat Op;
+
+  PetscFunctionBegin;
+  PetscCall(STGetOperator(st,&Op));
+  PetscCall(MatComputeOperator(Op,MATAIJ,A));
+  PetscCall(STRestoreOperator(st,&Op));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+SLEPC_EXTERN PetscErrorCode STApply(ST,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode STApplyMat(ST,Mat,Mat);
+SLEPC_EXTERN PetscErrorCode STApplyTranspose(ST,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode STApplyHermitianTranspose(ST,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode STMatMult(ST,PetscInt,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode STMatMultTranspose(ST,PetscInt,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode STMatMultHermitianTranspose(ST,PetscInt,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode STMatSolve(ST,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode STMatSolveTranspose(ST,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode STMatSolveHermitianTranspose(ST,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode STMatMatSolve(ST,Mat,Mat);
+SLEPC_EXTERN PetscErrorCode STGetBilinearForm(ST,Mat*);
+SLEPC_EXTERN PetscErrorCode STMatSetUp(ST,PetscScalar,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode STPostSolve(ST);
+SLEPC_EXTERN PetscErrorCode STResetMatrixState(ST);
+SLEPC_EXTERN PetscErrorCode STSetWorkVecs(ST,PetscInt);
+
+SLEPC_EXTERN PetscErrorCode STSetKSP(ST,KSP);
+SLEPC_EXTERN PetscErrorCode STGetKSP(ST,KSP*);
+SLEPC_EXTERN PetscErrorCode STSetShift(ST,PetscScalar);
+SLEPC_EXTERN PetscErrorCode STGetShift(ST,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode STSetDefaultShift(ST,PetscScalar);
+SLEPC_EXTERN PetscErrorCode STScaleShift(ST,PetscScalar);
+SLEPC_EXTERN PetscErrorCode STSetBalanceMatrix(ST,Vec);
+SLEPC_EXTERN PetscErrorCode STGetBalanceMatrix(ST,Vec*);
+SLEPC_EXTERN PetscErrorCode STSetTransform(ST,PetscBool);
+SLEPC_EXTERN PetscErrorCode STGetTransform(ST,PetscBool*);
+SLEPC_EXTERN PetscErrorCode STSetStructured(ST,PetscBool);
+SLEPC_EXTERN PetscErrorCode STGetStructured(ST,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode STSetOptionsPrefix(ST,const char*);
+SLEPC_EXTERN PetscErrorCode STAppendOptionsPrefix(ST,const char*);
+SLEPC_EXTERN PetscErrorCode STGetOptionsPrefix(ST,const char*[]);
+
+SLEPC_EXTERN PetscErrorCode STBackTransform(ST,PetscInt,PetscScalar*,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode STIsInjective(ST,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode STCheckNullSpace(ST,BV);
+
+SLEPC_EXTERN PetscErrorCode STSetPreconditionerMat(ST,Mat);
+SLEPC_EXTERN PetscErrorCode STGetPreconditionerMat(ST,Mat*);
+SLEPC_EXTERN PetscErrorCode STSetSplitPreconditioner(ST,PetscInt,Mat[],MatStructure);
+SLEPC_EXTERN PetscErrorCode STGetSplitPreconditionerTerm(ST,PetscInt,Mat*);
+SLEPC_EXTERN PetscErrorCode STGetSplitPreconditionerInfo(ST,PetscInt*,MatStructure*);
+
+SLEPC_EXTERN PetscErrorCode STMatCreateVecs(ST,Vec*,Vec*);
+SLEPC_EXTERN PetscErrorCode STMatCreateVecsEmpty(ST,Vec*,Vec*);
+SLEPC_EXTERN PetscErrorCode STMatGetSize(ST,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode STMatGetLocalSize(ST,PetscInt*,PetscInt*);
+
+/*E
+    STMatMode - Determines how to handle the coefficient matrix associated
+    to the spectral transformation
+
+    Level: intermediate
+
+.seealso: STSetMatMode(), STGetMatMode()
+E*/
+typedef enum { ST_MATMODE_COPY,
+               ST_MATMODE_INPLACE,
+               ST_MATMODE_SHELL } STMatMode;
+SLEPC_EXTERN const char *STMatModes[];
+
+SLEPC_EXTERN PetscErrorCode STSetMatMode(ST,STMatMode);
+SLEPC_EXTERN PetscErrorCode STGetMatMode(ST,STMatMode*);
+SLEPC_EXTERN PetscErrorCode STSetMatStructure(ST,MatStructure);
+SLEPC_EXTERN PetscErrorCode STGetMatStructure(ST,MatStructure*);
+
+SLEPC_EXTERN PetscFunctionList STList;
+SLEPC_EXTERN PetscErrorCode STRegister(const char[],PetscErrorCode(*)(ST));
+
+/* --------- options specific to particular spectral transformations-------- */
+
+SLEPC_EXTERN PetscErrorCode STShellGetContext(ST,void*);
+SLEPC_EXTERN PetscErrorCode STShellSetContext(ST,void*);
+SLEPC_EXTERN PetscErrorCode STShellSetApply(ST,PetscErrorCode (*)(ST,Vec,Vec));
+SLEPC_EXTERN PetscErrorCode STShellSetApplyTranspose(ST,PetscErrorCode (*)(ST,Vec,Vec));
+SLEPC_EXTERN PetscErrorCode STShellSetApplyHermitianTranspose(ST,PetscErrorCode (*)(ST,Vec,Vec));
+SLEPC_EXTERN PetscErrorCode STShellSetBackTransform(ST,PetscErrorCode (*)(ST,PetscInt,PetscScalar*,PetscScalar*));
+
+SLEPC_EXTERN PetscErrorCode STCayleyGetAntishift(ST,PetscScalar*);
+SLEPC_EXTERN PetscErrorCode STCayleySetAntishift(ST,PetscScalar);
+
+PETSC_DEPRECATED_FUNCTION(3, 15, 0, "STGetPreconditionerMat()", ) static inline PetscErrorCode STPrecondGetMatForPC(ST st,Mat *A) {return STGetPreconditionerMat(st,A);}
+PETSC_DEPRECATED_FUNCTION(3, 15, 0, "STSetPreconditionerMat()", ) static inline PetscErrorCode STPrecondSetMatForPC(ST st,Mat A) {return STSetPreconditionerMat(st,A);}
+SLEPC_EXTERN PetscErrorCode STPrecondGetKSPHasMat(ST,PetscBool*);
+SLEPC_EXTERN PetscErrorCode STPrecondSetKSPHasMat(ST,PetscBool);
+
+SLEPC_EXTERN PetscErrorCode STFilterSetInterval(ST,PetscReal,PetscReal);
+SLEPC_EXTERN PetscErrorCode STFilterGetInterval(ST,PetscReal*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode STFilterSetRange(ST,PetscReal,PetscReal);
+SLEPC_EXTERN PetscErrorCode STFilterGetRange(ST,PetscReal*,PetscReal*);
+SLEPC_EXTERN PetscErrorCode STFilterSetDegree(ST,PetscInt);
+SLEPC_EXTERN PetscErrorCode STFilterGetDegree(ST,PetscInt*);
+SLEPC_EXTERN PetscErrorCode STFilterGetThreshold(ST,PetscReal*);

--- a/3rd/slepc/linux/include/slepcsvd.h
+++ b/3rd/slepc/linux/include/slepcsvd.h
@@ -1,0 +1,360 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   User interface for SLEPc's singular value solvers
+*/
+
+#pragma once
+
+#include <slepceps.h>
+#include <slepcbv.h>
+#include <slepcds.h>
+
+/* SUBMANSEC = SVD */
+
+SLEPC_EXTERN PetscErrorCode SVDInitializePackage(void);
+SLEPC_EXTERN PetscErrorCode SVDFinalizePackage(void);
+
+/*S
+     SVD - Abstract SLEPc object that manages all the singular value
+     problem solvers.
+
+   Level: beginner
+
+.seealso:  SVDCreate()
+S*/
+typedef struct _p_SVD* SVD;
+
+/*J
+    SVDType - String with the name of a SLEPc singular value solver
+
+   Level: beginner
+
+.seealso: SVDSetType(), SVD
+J*/
+typedef const char* SVDType;
+#define SVDCROSS       "cross"
+#define SVDCYCLIC      "cyclic"
+#define SVDLAPACK      "lapack"
+#define SVDLANCZOS     "lanczos"
+#define SVDTRLANCZOS   "trlanczos"
+#define SVDRANDOMIZED  "randomized"
+#define SVDSCALAPACK   "scalapack"
+#define SVDKSVD        "ksvd"
+#define SVDELEMENTAL   "elemental"
+#define SVDPRIMME      "primme"
+
+/* Logging support */
+SLEPC_EXTERN PetscClassId SVD_CLASSID;
+
+/*E
+    SVDProblemType - Determines the type of singular value problem
+
+    Level: beginner
+
+.seealso: SVDSetProblemType(), SVDGetProblemType()
+E*/
+typedef enum { SVD_STANDARD=1,
+               SVD_GENERALIZED,   /* GSVD */
+               SVD_HYPERBOLIC     /* HSVD */
+             } SVDProblemType;
+
+/*E
+    SVDWhich - Determines whether largest or smallest singular triplets
+    are to be computed
+
+    Level: intermediate
+
+.seealso: SVDSetWhichSingularTriplets(), SVDGetWhichSingularTriplets()
+E*/
+typedef enum { SVD_LARGEST,
+               SVD_SMALLEST } SVDWhich;
+
+/*E
+    SVDErrorType - The error type used to assess accuracy of computed solutions
+
+    Level: intermediate
+
+.seealso: SVDComputeError()
+E*/
+typedef enum { SVD_ERROR_ABSOLUTE,
+               SVD_ERROR_RELATIVE,
+               SVD_ERROR_NORM } SVDErrorType;
+SLEPC_EXTERN const char *SVDErrorTypes[];
+
+/*E
+    SVDConv - Determines the convergence test
+
+    Level: intermediate
+
+.seealso: SVDSetConvergenceTest(), SVDSetConvergenceTestFunction()
+E*/
+typedef enum { SVD_CONV_ABS,
+               SVD_CONV_REL,
+               SVD_CONV_NORM,
+               SVD_CONV_MAXIT,
+               SVD_CONV_USER } SVDConv;
+
+/*E
+    SVDStop - Determines the stopping test
+
+    Level: advanced
+
+.seealso: SVDSetStoppingTest(), SVDSetStoppingTestFunction()
+E*/
+typedef enum { SVD_STOP_BASIC,
+               SVD_STOP_USER } SVDStop;
+
+/*E
+    SVDConvergedReason - Reason a singular value solver was said to
+         have converged or diverged
+
+   Level: intermediate
+
+.seealso: SVDSolve(), SVDGetConvergedReason(), SVDSetTolerances()
+E*/
+typedef enum {/* converged */
+              SVD_CONVERGED_TOL                =  1,
+              SVD_CONVERGED_USER               =  2,
+              SVD_CONVERGED_MAXIT              =  3,
+              /* diverged */
+              SVD_DIVERGED_ITS                 = -1,
+              SVD_DIVERGED_BREAKDOWN           = -2,
+              SVD_DIVERGED_SYMMETRY_LOST       = -3,
+              SVD_CONVERGED_ITERATING          =  0 } SVDConvergedReason;
+SLEPC_EXTERN const char *const*SVDConvergedReasons;
+
+SLEPC_EXTERN PetscErrorCode SVDCreate(MPI_Comm,SVD*);
+SLEPC_EXTERN PetscErrorCode SVDSetBV(SVD,BV,BV);
+SLEPC_EXTERN PetscErrorCode SVDGetBV(SVD,BV*,BV*);
+SLEPC_EXTERN PetscErrorCode SVDSetDS(SVD,DS);
+SLEPC_EXTERN PetscErrorCode SVDGetDS(SVD,DS*);
+SLEPC_EXTERN PetscErrorCode SVDSetType(SVD,SVDType);
+SLEPC_EXTERN PetscErrorCode SVDGetType(SVD,SVDType*);
+SLEPC_EXTERN PetscErrorCode SVDSetProblemType(SVD,SVDProblemType);
+SLEPC_EXTERN PetscErrorCode SVDGetProblemType(SVD,SVDProblemType*);
+SLEPC_EXTERN PetscErrorCode SVDIsGeneralized(SVD,PetscBool*);
+SLEPC_EXTERN PetscErrorCode SVDIsHyperbolic(SVD,PetscBool*);
+SLEPC_EXTERN PetscErrorCode SVDSetOperators(SVD,Mat,Mat);
+PETSC_DEPRECATED_FUNCTION(3, 15, 0, "SVDSetOperators()", ) static inline PetscErrorCode SVDSetOperator(SVD svd,Mat A) {return SVDSetOperators(svd,A,PETSC_NULLPTR);}
+SLEPC_EXTERN PetscErrorCode SVDGetOperators(SVD,Mat*,Mat*);
+PETSC_DEPRECATED_FUNCTION(3, 15, 0, "SVDGetOperators()", ) static inline PetscErrorCode SVDGetOperator(SVD svd,Mat *A) {return SVDGetOperators(svd,A,PETSC_NULLPTR);}
+SLEPC_EXTERN PetscErrorCode SVDSetSignature(SVD,Vec);
+SLEPC_EXTERN PetscErrorCode SVDGetSignature(SVD,Vec);
+SLEPC_EXTERN PetscErrorCode SVDSetInitialSpaces(SVD,PetscInt,Vec[],PetscInt,Vec[]);
+PETSC_DEPRECATED_FUNCTION(3, 1, 0, "SVDSetInitialSpaces()", ) static inline PetscErrorCode SVDSetInitialSpace(SVD svd,PetscInt nr,Vec *isr) {return SVDSetInitialSpaces(svd,nr,isr,0,PETSC_NULLPTR);}
+PETSC_DEPRECATED_FUNCTION(3, 1, 0, "SVDSetInitialSpaces()", ) static inline PetscErrorCode SVDSetInitialSpaceLeft(SVD svd,PetscInt nl,Vec *isl) {return SVDSetInitialSpaces(svd,0,PETSC_NULLPTR,nl,isl);}
+SLEPC_EXTERN PetscErrorCode SVDSetImplicitTranspose(SVD,PetscBool);
+SLEPC_EXTERN PetscErrorCode SVDGetImplicitTranspose(SVD,PetscBool*);
+SLEPC_EXTERN PetscErrorCode SVDSetDimensions(SVD,PetscInt,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode SVDGetDimensions(SVD,PetscInt*,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode SVDSetTolerances(SVD,PetscReal,PetscInt);
+SLEPC_EXTERN PetscErrorCode SVDGetTolerances(SVD,PetscReal*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode SVDSetWhichSingularTriplets(SVD,SVDWhich);
+SLEPC_EXTERN PetscErrorCode SVDGetWhichSingularTriplets(SVD,SVDWhich*);
+SLEPC_EXTERN PetscErrorCode SVDSetFromOptions(SVD);
+SLEPC_EXTERN PetscErrorCode SVDSetOptionsPrefix(SVD,const char*);
+SLEPC_EXTERN PetscErrorCode SVDAppendOptionsPrefix(SVD,const char*);
+SLEPC_EXTERN PetscErrorCode SVDGetOptionsPrefix(SVD,const char*[]);
+SLEPC_EXTERN PetscErrorCode SVDSetDSType(SVD);
+SLEPC_EXTERN PetscErrorCode SVDSetUp(SVD);
+SLEPC_EXTERN PetscErrorCode SVDSolve(SVD);
+SLEPC_EXTERN PetscErrorCode SVDGetIterationNumber(SVD,PetscInt*);
+SLEPC_EXTERN PetscErrorCode SVDSetConvergenceTest(SVD,SVDConv);
+SLEPC_EXTERN PetscErrorCode SVDGetConvergenceTest(SVD,SVDConv*);
+SLEPC_EXTERN PetscErrorCode SVDConvergedAbsolute(SVD,PetscReal,PetscReal,PetscReal*,void*);
+SLEPC_EXTERN PetscErrorCode SVDConvergedRelative(SVD,PetscReal,PetscReal,PetscReal*,void*);
+SLEPC_EXTERN PetscErrorCode SVDConvergedNorm(SVD,PetscReal,PetscReal,PetscReal*,void*);
+SLEPC_EXTERN PetscErrorCode SVDConvergedMaxIt(SVD,PetscReal,PetscReal,PetscReal*,void*);
+SLEPC_EXTERN PetscErrorCode SVDSetStoppingTest(SVD,SVDStop);
+SLEPC_EXTERN PetscErrorCode SVDGetStoppingTest(SVD,SVDStop*);
+SLEPC_EXTERN PetscErrorCode SVDStoppingBasic(SVD,PetscInt,PetscInt,PetscInt,PetscInt,SVDConvergedReason*,void*);
+SLEPC_EXTERN PetscErrorCode SVDGetConvergedReason(SVD,SVDConvergedReason*);
+SLEPC_EXTERN PetscErrorCode SVDGetConverged(SVD,PetscInt*);
+SLEPC_EXTERN PetscErrorCode SVDGetSingularTriplet(SVD,PetscInt,PetscReal*,Vec,Vec);
+SLEPC_EXTERN PetscErrorCode SVDComputeError(SVD,PetscInt,SVDErrorType,PetscReal*);
+PETSC_DEPRECATED_FUNCTION(3, 6, 0, "SVDComputeError()", ) static inline PetscErrorCode SVDComputeRelativeError(SVD svd,PetscInt i,PetscReal *r) {return SVDComputeError(svd,i,SVD_ERROR_RELATIVE,r);}
+PETSC_DEPRECATED_FUNCTION(3, 6, 0, "SVDComputeError() with SVD_ERROR_ABSOLUTE", ) static inline PetscErrorCode SVDComputeResidualNorms(SVD svd,PetscInt i,PetscReal *r1,PETSC_UNUSED PetscReal *r2) {return SVDComputeError(svd,i,SVD_ERROR_ABSOLUTE,r1);}
+SLEPC_EXTERN PetscErrorCode SVDView(SVD,PetscViewer);
+SLEPC_EXTERN PetscErrorCode SVDViewFromOptions(SVD,PetscObject,const char[]);
+SLEPC_EXTERN PetscErrorCode SVDErrorView(SVD,SVDErrorType,PetscViewer);
+PETSC_DEPRECATED_FUNCTION(3, 6, 0, "SVDErrorView()", ) static inline PetscErrorCode SVDPrintSolution(SVD svd,PetscViewer v) {return SVDErrorView(svd,SVD_ERROR_RELATIVE,v);}
+SLEPC_EXTERN PetscErrorCode SVDErrorViewFromOptions(SVD);
+SLEPC_EXTERN PetscErrorCode SVDConvergedReasonView(SVD,PetscViewer);
+SLEPC_EXTERN PetscErrorCode SVDConvergedReasonViewFromOptions(SVD);
+PETSC_DEPRECATED_FUNCTION(3, 14, 0, "SVDConvergedReasonView()", ) static inline PetscErrorCode SVDReasonView(SVD svd,PetscViewer v) {return SVDConvergedReasonView(svd,v);}
+PETSC_DEPRECATED_FUNCTION(3, 14, 0, "SVDConvergedReasonViewFromOptions()", ) static inline PetscErrorCode SVDReasonViewFromOptions(SVD svd) {return SVDConvergedReasonViewFromOptions(svd);}
+SLEPC_EXTERN PetscErrorCode SVDValuesView(SVD,PetscViewer);
+SLEPC_EXTERN PetscErrorCode SVDValuesViewFromOptions(SVD);
+SLEPC_EXTERN PetscErrorCode SVDVectorsView(SVD,PetscViewer);
+SLEPC_EXTERN PetscErrorCode SVDVectorsViewFromOptions(SVD);
+SLEPC_EXTERN PetscErrorCode SVDDestroy(SVD*);
+SLEPC_EXTERN PetscErrorCode SVDReset(SVD);
+SLEPC_EXTERN PetscErrorCode SVDSetWorkVecs(SVD,PetscInt,PetscInt);
+SLEPC_EXTERN PetscErrorCode SVDSetTrackAll(SVD,PetscBool);
+SLEPC_EXTERN PetscErrorCode SVDGetTrackAll(SVD,PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode SVDMonitor(SVD,PetscInt,PetscInt,PetscReal*,PetscReal*,PetscInt);
+SLEPC_EXTERN PetscErrorCode SVDMonitorSet(SVD,PetscErrorCode (*)(SVD,PetscInt,PetscInt,PetscReal*,PetscReal*,PetscInt,void*),void*,PetscErrorCode (*)(void**));
+SLEPC_EXTERN PetscErrorCode SVDMonitorCancel(SVD);
+SLEPC_EXTERN PetscErrorCode SVDGetMonitorContext(SVD,void*);
+
+SLEPC_EXTERN PetscErrorCode SVDMonitorSetFromOptions(SVD,const char[],const char[],void*,PetscBool);
+SLEPC_EXTERN PetscErrorCode SVDMonitorLGCreate(MPI_Comm,const char[],const char[],const char[],PetscInt,const char*[],int,int,int,int,PetscDrawLG*);
+SLEPC_EXTERN PetscErrorCode SVDMonitorFirst(SVD,PetscInt,PetscInt,PetscReal*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode SVDMonitorFirstDrawLG(SVD,PetscInt,PetscInt,PetscReal*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode SVDMonitorFirstDrawLGCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode SVDMonitorAll(SVD,PetscInt,PetscInt,PetscReal*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode SVDMonitorAllDrawLG(SVD,PetscInt,PetscInt,PetscReal*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode SVDMonitorAllDrawLGCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode SVDMonitorConverged(SVD,PetscInt,PetscInt,PetscReal*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode SVDMonitorConvergedCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode SVDMonitorConvergedDrawLG(SVD,PetscInt,PetscInt,PetscReal*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+SLEPC_EXTERN PetscErrorCode SVDMonitorConvergedDrawLGCreate(PetscViewer,PetscViewerFormat,void *,PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode SVDMonitorConvergedDestroy(PetscViewerAndFormat**);
+SLEPC_EXTERN PetscErrorCode SVDMonitorConditioning(SVD,PetscInt,PetscInt,PetscReal*,PetscReal*,PetscInt,PetscViewerAndFormat*);
+
+SLEPC_EXTERN PetscFunctionList SVDList;
+SLEPC_EXTERN PetscFunctionList SVDMonitorList;
+SLEPC_EXTERN PetscFunctionList SVDMonitorCreateList;
+SLEPC_EXTERN PetscFunctionList SVDMonitorDestroyList;
+SLEPC_EXTERN PetscErrorCode SVDRegister(const char[],PetscErrorCode(*)(SVD));
+SLEPC_EXTERN PetscErrorCode SVDMonitorRegister(const char[],PetscViewerType,PetscViewerFormat,PetscErrorCode(*)(SVD,PetscInt,PetscInt,PetscReal*,PetscReal*,PetscInt,PetscViewerAndFormat*),PetscErrorCode(*)(PetscViewer,PetscViewerFormat,void*,PetscViewerAndFormat**),PetscErrorCode(*)(PetscViewerAndFormat**));
+
+SLEPC_EXTERN PetscErrorCode SVDAllocateSolution(SVD,PetscInt);
+
+/*S
+  SVDConvergenceTestFn - A prototype of an SVD convergence test function that would be passed to SVDSetConvergenceTestFunction()
+
+  Calling Sequence:
++   svd    - singular value solver context obtained from SVDCreate()
+.   sigma  - computed singular value
+.   res    - residual norm associated to the singular triplet
+.   errest - [output] computed error estimate
+-   ctx    - [optional] user-defined context for private data for the
+             convergence test routine (may be NULL)
+
+  Level: advanced
+
+.seealso: SVDSetConvergenceTestFunction()
+S*/
+PETSC_EXTERN_TYPEDEF typedef PetscErrorCode(SVDConvergenceTestFn)(SVD svd,PetscReal sigma,PetscReal res,PetscReal *errest,void *ctx);
+
+/*S
+  SVDStoppingTestFn - A prototype of an SVD stopping test function that would be passed to SVDSetStoppingTestFunction()
+
+  Calling Sequence:
++   svd    - singular value solver context obtained from SVDCreate()
+.   its    - current number of iterations
+.   max_it - maximum number of iterations
+.   nconv  - number of currently converged singular triplets
+.   nsv    - number of requested singular triplets
+.   reason - [output] result of the stopping test
+-   ctx    - [optional] user-defined context for private data for the
+             stopping test routine (may be NULL)
+
+  Level: advanced
+
+.seealso: SVDSetStoppingTestFunction()
+S*/
+PETSC_EXTERN_TYPEDEF typedef PetscErrorCode(SVDStoppingTestFn)(SVD svd,PetscInt its,PetscInt max_it,PetscInt nconv,PetscInt nsv,SVDConvergedReason *reason,void *ctx);
+
+SLEPC_EXTERN PetscErrorCode SVDSetConvergenceTestFunction(SVD,SVDConvergenceTestFn*,void*,PetscErrorCode (*)(void*));
+SLEPC_EXTERN PetscErrorCode SVDSetStoppingTestFunction(SVD,SVDStoppingTestFn*,void*,PetscErrorCode (*)(void*));
+
+/* --------- options specific to particular solvers -------- */
+
+SLEPC_EXTERN PetscErrorCode SVDCrossSetExplicitMatrix(SVD,PetscBool);
+SLEPC_EXTERN PetscErrorCode SVDCrossGetExplicitMatrix(SVD,PetscBool*);
+SLEPC_EXTERN PetscErrorCode SVDCrossSetEPS(SVD,EPS);
+SLEPC_EXTERN PetscErrorCode SVDCrossGetEPS(SVD,EPS*);
+
+SLEPC_EXTERN PetscErrorCode SVDCyclicSetExplicitMatrix(SVD,PetscBool);
+SLEPC_EXTERN PetscErrorCode SVDCyclicGetExplicitMatrix(SVD,PetscBool*);
+SLEPC_EXTERN PetscErrorCode SVDCyclicSetEPS(SVD,EPS);
+SLEPC_EXTERN PetscErrorCode SVDCyclicGetEPS(SVD,EPS*);
+
+SLEPC_EXTERN PetscErrorCode SVDLanczosSetOneSide(SVD,PetscBool);
+SLEPC_EXTERN PetscErrorCode SVDLanczosGetOneSide(SVD,PetscBool*);
+
+/*E
+    SVDTRLanczosGBidiag - determines the bidiagonalization choice for the
+    TRLanczos GSVD solver
+
+    Level: advanced
+
+.seealso: SVDTRLanczosSetGBidiag(), SVDTRLanczosGetGBidiag()
+E*/
+typedef enum {
+  SVD_TRLANCZOS_GBIDIAG_SINGLE, /* single bidiagonalization (Qa) */
+  SVD_TRLANCZOS_GBIDIAG_UPPER,  /* joint bidiagonalization, both Qa and Qb in upper bidiagonal form */
+  SVD_TRLANCZOS_GBIDIAG_LOWER   /* joint bidiagonalization, Qa lower bidiagonal, Qb upper bidiagonal */
+} SVDTRLanczosGBidiag;
+SLEPC_EXTERN const char *SVDTRLanczosGBidiags[];
+
+SLEPC_EXTERN PetscErrorCode SVDTRLanczosSetGBidiag(SVD,SVDTRLanczosGBidiag);
+SLEPC_EXTERN PetscErrorCode SVDTRLanczosGetGBidiag(SVD,SVDTRLanczosGBidiag*);
+SLEPC_EXTERN PetscErrorCode SVDTRLanczosSetOneSide(SVD,PetscBool);
+SLEPC_EXTERN PetscErrorCode SVDTRLanczosGetOneSide(SVD,PetscBool*);
+SLEPC_EXTERN PetscErrorCode SVDTRLanczosSetKSP(SVD,KSP);
+SLEPC_EXTERN PetscErrorCode SVDTRLanczosGetKSP(SVD,KSP*);
+SLEPC_EXTERN PetscErrorCode SVDTRLanczosSetRestart(SVD,PetscReal);
+SLEPC_EXTERN PetscErrorCode SVDTRLanczosGetRestart(SVD,PetscReal*);
+SLEPC_EXTERN PetscErrorCode SVDTRLanczosSetLocking(SVD,PetscBool);
+SLEPC_EXTERN PetscErrorCode SVDTRLanczosGetLocking(SVD,PetscBool*);
+SLEPC_EXTERN PetscErrorCode SVDTRLanczosSetExplicitMatrix(SVD,PetscBool);
+SLEPC_EXTERN PetscErrorCode SVDTRLanczosGetExplicitMatrix(SVD,PetscBool*);
+SLEPC_EXTERN PetscErrorCode SVDTRLanczosSetScale(SVD,PetscReal);
+SLEPC_EXTERN PetscErrorCode SVDTRLanczosGetScale(SVD,PetscReal*);
+
+/*E
+    SVDPRIMMEMethod - determines the SVD method selected in the PRIMME library
+
+    Level: advanced
+
+.seealso: SVDPRIMMESetMethod(), SVDPRIMMEGetMethod()
+E*/
+typedef enum { SVD_PRIMME_HYBRID=1,
+               SVD_PRIMME_NORMALEQUATIONS,
+               SVD_PRIMME_AUGMENTED } SVDPRIMMEMethod;
+SLEPC_EXTERN const char *SVDPRIMMEMethods[];
+
+SLEPC_EXTERN PetscErrorCode SVDPRIMMESetBlockSize(SVD,PetscInt);
+SLEPC_EXTERN PetscErrorCode SVDPRIMMEGetBlockSize(SVD,PetscInt*);
+SLEPC_EXTERN PetscErrorCode SVDPRIMMESetMethod(SVD,SVDPRIMMEMethod);
+SLEPC_EXTERN PetscErrorCode SVDPRIMMEGetMethod(SVD,SVDPRIMMEMethod*);
+
+/*E
+    SVDKSVDEigenMethod - determines the method to solve the eigenproblem within KSVD
+
+    Level: advanced
+
+.seealso: SVDKSVDSetEigenMethod(), SVDKSVDGetEigenMethod()
+E*/
+typedef enum { SVD_KSVD_EIGEN_MRRR=1,
+               SVD_KSVD_EIGEN_DC,
+               SVD_KSVD_EIGEN_ELPA } SVDKSVDEigenMethod;
+SLEPC_EXTERN const char *SVDKSVDEigenMethods[];
+
+/*E
+    SVDKSVDPolarMethod - determines the method to compute the polar decomposition within KSVD
+
+    Level: advanced
+
+.seealso: SVDKSVDSetPolarMethod(), SVDKSVDGetPolarMethod()
+E*/
+typedef enum { SVD_KSVD_POLAR_QDWH=1,
+               SVD_KSVD_POLAR_ZOLOPD } SVDKSVDPolarMethod;
+SLEPC_EXTERN const char *SVDKSVDPolarMethods[];
+
+SLEPC_EXTERN PetscErrorCode SVDKSVDSetEigenMethod(SVD,SVDKSVDEigenMethod);
+SLEPC_EXTERN PetscErrorCode SVDKSVDGetEigenMethod(SVD,SVDKSVDEigenMethod*);
+SLEPC_EXTERN PetscErrorCode SVDKSVDSetPolarMethod(SVD,SVDKSVDPolarMethod);
+SLEPC_EXTERN PetscErrorCode SVDKSVDGetPolarMethod(SVD,SVDKSVDPolarMethod*);

--- a/3rd/slepc/linux/include/slepcsys.h
+++ b/3rd/slepc/linux/include/slepcsys.h
@@ -1,0 +1,121 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   This include file contains definitions of system functions. It is included
+   by all other SLEPc include files.
+*/
+
+#pragma once
+
+#include <petscsys.h>
+
+/* SUBMANSEC = sys */
+
+#if defined(slepc_EXPORTS)
+#define SLEPC_VISIBILITY_PUBLIC PETSC_DLLEXPORT
+#else
+#define SLEPC_VISIBILITY_PUBLIC PETSC_DLLIMPORT
+#endif
+#define SLEPC_VISIBILITY_INTERNAL PETSC_VISIBILITY_INTERNAL
+
+/*
+    Functions tagged with SLEPC_EXTERN in the header files are
+  always defined as extern "C" when compiled with C++ so they may be
+  used from C and are always visible in the shared libraries
+*/
+#if defined(__cplusplus)
+#define SLEPC_EXTERN extern "C" SLEPC_VISIBILITY_PUBLIC
+#define SLEPC_INTERN extern "C" SLEPC_VISIBILITY_INTERNAL
+#else
+#define SLEPC_EXTERN extern SLEPC_VISIBILITY_PUBLIC
+#define SLEPC_INTERN extern SLEPC_VISIBILITY_INTERNAL
+#endif
+
+#if defined(PETSC_USE_SINGLE_LIBRARY)
+  #define SLEPC_SINGLE_LIBRARY_VISIBILITY_INTERNAL SLEPC_VISIBILITY_INTERNAL
+  #define SLEPC_SINGLE_LIBRARY_INTERN              SLEPC_INTERN
+#else
+  #define SLEPC_SINGLE_LIBRARY_VISIBILITY_INTERNAL SLEPC_VISIBILITY_PUBLIC
+  #define SLEPC_SINGLE_LIBRARY_INTERN              SLEPC_EXTERN
+#endif
+
+/* ========================================================================== */
+/*
+   slepcconf.h is created by the configure script and placed in ${PETSC_ARCH}/include.
+   It contains macro definitions set at configure time.
+*/
+#include <slepcconf.h>
+/*
+    slepcversion.h contains version info
+*/
+#include <slepcversion.h>
+#define SLEPC_AUTHOR_INFO "       The SLEPc Team\n    slepc-maint@upv.es\n https://slepc.upv.es\n"
+
+/* ========================================================================== */
+/*
+   The PETSc include files.
+*/
+#include <petscmat.h>
+/*
+    slepcmath.h contains definition of basic math functions
+*/
+#include <slepcmath.h>
+/*
+    slepcsc.h contains definition of sorting criterion
+*/
+#include <slepcsc.h>
+/*
+    slepcmat.h, slepcvec.h contain utilities related to Mat and Vec, extend functionality in PETSc
+*/
+#include <slepcmat.h>
+#include <slepcvec.h>
+
+/*
+    Context for monitors of type XXXMonitorConverged
+*/
+typedef struct _n_SlepcConvMon* SlepcConvMon;
+
+/*
+    Initialization of SLEPc and other system routines
+*/
+SLEPC_EXTERN PetscErrorCode SlepcInitialize(int*,char***,const char[],const char[]);
+SLEPC_EXTERN PetscErrorCode SlepcInitializeNoPointers(int,char**,const char[],const char[]);
+SLEPC_EXTERN PetscErrorCode SlepcInitializeNoArguments(void);
+SLEPC_EXTERN PetscErrorCode SlepcFinalize(void);
+SLEPC_EXTERN PetscErrorCode SlepcInitializeFortran(void);
+SLEPC_EXTERN PetscErrorCode SlepcInitialized(PetscBool*);
+SLEPC_EXTERN PetscErrorCode SlepcFinalized(PetscBool*);
+SLEPC_EXTERN PetscErrorCode SlepcGetVersion(char[],size_t);
+SLEPC_EXTERN PetscErrorCode SlepcGetVersionNumber(PetscInt*,PetscInt*,PetscInt*,PetscInt*);
+SLEPC_EXTERN PetscErrorCode SlepcHasExternalPackage(const char[],PetscBool*);
+
+SLEPC_EXTERN PetscErrorCode SlepcSNPrintfScalar(char*,size_t,PetscScalar,PetscBool);
+
+SLEPC_EXTERN PetscBool SlepcInitializeCalled;
+SLEPC_EXTERN PetscBool SlepcFinalizeCalled;
+
+#if defined(PETSC_USE_COMPLEX)
+#define SlepcLogFlopsComplex(a) PetscLogFlops((a))
+#else
+#define SlepcLogFlopsComplex(a) PetscLogFlops((4.0*a))
+#endif
+
+#if defined(PETSC_USE_COMPLEX)
+#define SlepcLogGpuFlopsComplex(a) PetscLogGpuFlops((a))
+#else
+#define SlepcLogGpuFlopsComplex(a) PetscLogGpuFlops((4.0*a))
+#endif
+
+/*
+    Developer routines to be used with a debugger
+*/
+#if defined(PETSC_USE_DEBUG)
+SLEPC_EXTERN PetscErrorCode SlepcDebugViewMatrix(PetscInt,PetscInt,PetscScalar*,PetscScalar*,PetscInt,const char*,const char*);
+#endif

--- a/3rd/slepc/linux/include/slepcvec.h
+++ b/3rd/slepc/linux/include/slepcvec.h
@@ -1,0 +1,37 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+/*
+   User interface for various vector operations added in SLEPc
+*/
+
+#pragma once
+
+#include <slepcsys.h>
+
+/* SUBMANSEC = sys */
+
+/* VecComp: Vec composed of several smaller Vecs */
+#define VECCOMP  "comp"
+
+SLEPC_EXTERN PetscErrorCode VecCreateComp(MPI_Comm,PetscInt*,PetscInt,VecType,Vec,Vec*);
+SLEPC_EXTERN PetscErrorCode VecCreateCompWithVecs(Vec*,PetscInt,Vec,Vec*);
+SLEPC_EXTERN PetscErrorCode VecCompGetSubVecs(Vec,PetscInt*,const Vec**);
+SLEPC_EXTERN PetscErrorCode VecCompSetSubVecs(Vec,PetscInt,Vec*);
+
+/* Some auxiliary functions */
+SLEPC_EXTERN PetscErrorCode VecNormalizeComplex(Vec,Vec,PetscBool,PetscReal*);
+SLEPC_EXTERN PetscErrorCode VecCheckOrthogonality(Vec[],PetscInt,Vec[],PetscInt,Mat,PetscViewer,PetscReal*);
+SLEPC_EXTERN PetscErrorCode VecCheckOrthonormality(Vec[],PetscInt,Vec[],PetscInt,Mat,PetscViewer,PetscReal*);
+SLEPC_EXTERN PetscErrorCode VecDuplicateEmpty(Vec,Vec*);
+SLEPC_EXTERN PetscErrorCode VecSetRandomNormal(Vec,PetscRandom,Vec,Vec);
+
+/* Deprecated functions */
+PETSC_DEPRECATED_FUNCTION(3, 8, 0, "VecNormalizeComplex()", ) static inline PetscErrorCode SlepcVecNormalize(Vec xr,Vec xi,PetscBool c,PetscReal *nrm) {return VecNormalizeComplex(xr,xi,c,nrm);}
+PETSC_DEPRECATED_FUNCTION(3, 8, 0, "VecCheckOrthogonality()", ) static inline PetscErrorCode SlepcCheckOrthogonality(Vec *V,PetscInt nv,Vec *W,PetscInt nw,Mat B,PetscViewer viewer,PetscReal *lev) {return VecCheckOrthogonality(V,nv,W,nw,B,viewer,lev);}

--- a/3rd/slepc/linux/include/slepcversion.h
+++ b/3rd/slepc/linux/include/slepcversion.h
@@ -1,0 +1,55 @@
+/*
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   SLEPc - Scalable Library for Eigenvalue Problem Computations
+   Copyright (c) 2002-, Universitat Politecnica de Valencia, Spain
+
+   This file is part of SLEPc.
+   SLEPc is distributed under a 2-clause BSD license (see LICENSE).
+   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+*/
+
+#ifndef SLEPCVERSION_H
+#define SLEPCVERSION_H
+
+#define SLEPC_VERSION_RELEASE    1
+#define SLEPC_VERSION_MAJOR      3
+#define SLEPC_VERSION_MINOR      22
+#define SLEPC_VERSION_SUBMINOR   2
+#define SLEPC_RELEASE_DATE       "September 29, 2024"
+#define SLEPC_VERSION_DATE       "Dec 02, 2024"
+
+#if !defined (SLEPC_VERSION_GIT)
+#define SLEPC_VERSION_GIT        "v3.22.2"
+#endif
+
+#if !defined(SLEPC_VERSION_DATE_GIT)
+#define SLEPC_VERSION_DATE_GIT   "2024-12-02 09:38:06 +0100"
+#endif
+
+#define SLEPC_VERSION_EQ(MAJOR,MINOR,SUBMINOR) \
+ ((SLEPC_VERSION_MAJOR == (MAJOR)) &&       \
+  (SLEPC_VERSION_MINOR == (MINOR)) &&       \
+  (SLEPC_VERSION_SUBMINOR == (SUBMINOR)) && \
+  (SLEPC_VERSION_RELEASE  == 1))
+
+#define SLEPC_VERSION_ SLEPC_VERSION_EQ
+
+#define SLEPC_VERSION_LT(MAJOR,MINOR,SUBMINOR)          \
+  (SLEPC_VERSION_RELEASE == 1 &&                        \
+   (SLEPC_VERSION_MAJOR < (MAJOR) ||                    \
+    (SLEPC_VERSION_MAJOR == (MAJOR) &&                  \
+     (SLEPC_VERSION_MINOR < (MINOR) ||                  \
+      (SLEPC_VERSION_MINOR == (MINOR) &&                \
+       (SLEPC_VERSION_SUBMINOR < (SUBMINOR)))))))
+
+#define SLEPC_VERSION_LE(MAJOR,MINOR,SUBMINOR) \
+  (SLEPC_VERSION_LT(MAJOR,MINOR,SUBMINOR) || \
+   SLEPC_VERSION_EQ(MAJOR,MINOR,SUBMINOR))
+
+#define SLEPC_VERSION_GT(MAJOR,MINOR,SUBMINOR) \
+  (0 == SLEPC_VERSION_LE(MAJOR,MINOR,SUBMINOR))
+
+#define SLEPC_VERSION_GE(MAJOR,MINOR,SUBMINOR) \
+  (0 == SLEPC_VERSION_LT(MAJOR,MINOR,SUBMINOR))
+
+#endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,5 +19,8 @@ include(linux_mpicc)
 # 载入 PETSc 配置
 include(PETScConfig)
 
+# 载入 SLEPc 配置
+include(SLEPcConfig)
+
 add_subdirectory(gcge)  # 添加 gcge 库的子目录
 add_subdirectory(src)   # 添加 src 可执行文件的子目录

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ make
     读入MTX矩阵到petsc格式的Mat中，再转换为CCS_MAT格式，调用串行版GCGE求解器
     目的是：验证MTX矩阵读入为petsc的Mat矩阵正确。
 
+
+### 四、待进一步明确事项
+  libpetsc.a的编译，使用“./configure --with-mpiexec=xx --with-blas-lib=/xxx/lib/libopenblas.a --with-lapack-lib=/xxx/lib/libopenblas.a  xxx”编译的libpetsc.a仅58M大小(上传了)，但是要依赖libmpifort.a等库，这些依赖库是按照另一种“./configure --with xxx”编译出来库(也有一个大小约229M的libpetsc.a)，这些库共同作用才能将petsc作为第三方库使用
+    
+    
 ### 附件：原始readme内容
 #### 外部包
 

--- a/cmake/SLEPcConfig.cmake
+++ b/cmake/SLEPcConfig.cmake
@@ -1,0 +1,24 @@
+# 定义 SLEPc 作为 INTERFACE 库
+add_library(SLEPC INTERFACE)
+
+# 判断当前系统
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set(SLEPC_DIR ${PROJECT_SOURCE_DIR}/3rd/slepc/windows)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(SLEPC_DIR ${PROJECT_SOURCE_DIR}/3rd/slepc/linux)
+else()
+    message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}")
+endif()
+
+set(SLEPC_INCLUDE_DIR ${SLEPC_DIR}/include)
+set(SLEPC_LIB_DIR ${SLEPC_DIR}/lib)
+set(SLEPC_LIB_NAME slepc)
+
+# 设置头文件路径
+target_include_directories(SLEPC INTERFACE ${SLEPC_INCLUDE_DIR})
+
+# 设置库文件搜索路径
+target_link_directories(SLEPC INTERFACE ${SLEPC_LIB_DIR})
+
+# 链接 SLEPc 库
+target_link_libraries(SLEPC INTERFACE ${SLEPC_LIB_NAME})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,10 +35,12 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/gcge/include
     ${PROJECT_SOURCE_DIR}/src
     ${PETSC_INCLUDE_DIR} # PETSc 头文件路径
+    ${SLEPC_INCLUDE_DIR} # SLEPc 头文件路径
 )
 # 设置库文件搜索路径
 link_directories(
     ${PETSC_LIB_DIR}
+    ${SLEPC_LIB_DIR}
 )
 
 file(GLOB_RECURSE ALL_SOURCES "*.cpp" "*.c" "*.h")
@@ -54,6 +56,7 @@ endif()
 
 if(UNIX)
     target_link_libraries(test PRIVATE 
+        "${SLEPC_DIR}/lib/libslepc.a"     # SLEPC需要放在PETSC之前
         "${PETSC_DIR}/lib/libpetsc.a"     # PETSC # todo: 这样写存在链接错误，为什么
         GCGE
         MPI::MPI_C          # MPI C 库， # todo: 采用${MPI_C_LIBRARIES}会失败，为什么

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,10 @@
 
 #include <petscmat.h>
 
+#if OPS_USE_SLEPC
+#include <slepcbv.h>
+#endif
+
 extern "C" {
 #include "app_ccs.h"
 #include "app_lapack.h"
@@ -32,7 +36,10 @@ int main(int argc, char *argv[])
         std::cerr << "Usage: mpiexec -n <b> program <sourceMatA.mtx> <sourceMatB.mtx> <paramFile.txt>" << std::endl;
         return GCGE_ERR_INPUT;
     }
-#if OPS_USE_PETSC
+    
+#if OPS_USE_SLEPC
+    SlepcInitialize(&argc, &argv, NULL, NULL);
+#elif OPS_USE_PETSC
     PetscFunctionBeginUser;
     PetscCall(PetscInitialize(&argc, &argv, NULL, NULL));
 #elif OPS_USE_MPI
@@ -138,7 +145,9 @@ int main(int argc, char *argv[])
 #endif
     destroyMatrixCCS(&sourceMatA, &sourceMatB);
 
-#if OPS_USE_PETSC
+#if OPS_USE_SLEPC
+    SlepcFinalize();
+#elif OPS_USE_PETSC
     PetscCall(PetscFinalize());
 #elif OPS_USE_MPI
     MPI_Finalize();


### PR DESCRIPTION
1.增加3rd/slepc/linux文件夹，并添加相应头文件和库文件；
2.增加SLEPcConfig.cmake文件；
3.调整相应的CMakeLists.txt内容，便于测试slepc；
4.在README.md记录了编译petsc库的情况。